### PR TITLE
Add ubuntu.18.04 dockerfile

### DIFF
--- a/ubuntu.18.04/Dockerfile
+++ b/ubuntu.18.04/Dockerfile
@@ -55,10 +55,6 @@ RUN wget https://releases.hashicorp.com/terraform/0.12.24/terraform_0.12.24_linu
     unzip terraform_0.12.24_linux_amd64.zip && \
     mv terraform /usr/local/bin
 
-# Get Azure Functions core tools 3
-# https://github.com/Azure/azure-functions-core-tools
-RUN apt-get install -y azure-functions-core-tools-3
-
 # Install Google Cloud CLI
 # https://cloud.google.com/sdk/docs/downloads-apt-get
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list


### PR DESCRIPTION
What it says on the box! This PR adds a dockerfile for `ubuntu.18.04` and all of the dependencies that we need and support. 

### Testing 
- [ ] I've built this dockerfile locally with `docker build .` 

### Acceptance Criteria 
Install the following dependencies 

- [x] PowerShell core
- [x] .NET Core SDK (3.1 LTS)
- [x] Java SDK
- [x] Azure CLI
- [x] Az Powershell Core Modules
- [x] AWS CLI
- [x] Node.js
- [x] kubectl
- [x] Helm 3
- [x] Terraform
- [x] Python
- [x] Azure Function Core Tools
- [x] Google Cloud CLI