### PR TITLE
Ubuntu: Add Octopus Client

### DIFF
--- a/ubuntu.18.04/Dockerfile
+++ b/ubuntu.18.04/Dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu:18.04
 
-ARG Powershell_Version=7.0.0-1.ubuntu.18.04
+ARG Powershell_Version=7.0.0\*
 ARG Octopus_Cli_Version=7.3.2
 ARG Octopus_Client_Version=8.4.0
 ARG Helm_Version=v3.0.2
-ARG Node_Version=12.16.1
+ARG Node_Version=12.16.2\*
 ARG Kubectl_Version=1.11.1-00
 ARG Terraform_Version=0.12.24
 ARG Ruby_Version=2.7.0

--- a/ubuntu.18.04/spec/ubuntu.18.04_spec.rb
+++ b/ubuntu.18.04/spec/ubuntu.18.04_spec.rb
@@ -32,7 +32,7 @@ end
 
 describe command('node --version') do
   its(:exit_status) { should eq(0) }
-  its(:stdout) { should contain(/v12.16.1/) }
+  its(:stdout) { should contain(/v12.16.2/) }
 end
 
 describe command('kubectl version') do


### PR DESCRIPTION
Added octopus client dll from nuget, and copied to the working directory so that sample scripts like [this one](https://github.com/OctopusDeploy/OctopusDeploy-Api/blob/master/Octopus.Client/PowerShell/Releases/CreateRelease.ps1) and [this one](https://github.com/OctopusDeploy/OctopusDeploy-Api/blob/master/Octopus.Client/PowerShell/Machines/AddAzureWebAppTargetToEnvironments.ps1) both work, e.g: 

```
Add-Type -Path 'Octopus.Client.dll' 
```

and/or

```
$path = Join-Path (Get-Item ((Get-Package Octopus.Client).source)).Directory.FullName "lib/netstandard2.0/Octopus.Client.dll"
Add-Type -Path $path
```

Elevated some version numbers to ARGs so that customers can build custom version numbers using our docker files e.g:

```
docker build OurDockerFile --build-arg Octopus_Cli_Version=X.Y.Z
```