### PR TITLE
fix octopus client version (this time with feeling)

### DIFF
--- a/ubuntu.18.04/Dockerfile
+++ b/ubuntu.18.04/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && \
 
 # Install Octopus Client
 # https://octopus.com/docs/octopus-rest-api/octopus.client
-RUN pwsh -c 'Install-Package -Force Octopus.Client -MaximumVersion ${Octopus_Client_Version} -source https://www.nuget.org/api/v2 -SkipDependencies' && \
+RUN pwsh -c 'Install-Package -Force Octopus.Client -MaximumVersion "'${Octopus_Client_Version}'" -source https://www.nuget.org/api/v2 -SkipDependencies' && \
     octopusClientPackagePath=$(pwsh -c '(Get-Item ((Get-Package Octopus.Client).source)).Directory.FullName') && \
     cp -r $octopusClientPackagePath/lib/netstandard2.0/* .
 


### PR DESCRIPTION
Currently build is failing with:

> expected "8.4.2.0\n" to contain /8.4.0.0/

TIL: Dockerfile syntax doesn't replace values within single quotes, e.g. 

fine:
```
RUN apt-get install -y octopuscli=${Octopus_Cli_Version}
```
not fine:
```
RUN pwsh -c 'Install-Package ... -MaximumVersion ${Octopus_ClientVersion}' <-- value inside string
```