### PR TITLE
Bump dependencies to latest as of August 2020

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ N.B. all commands below should be run from the project root directory.
 
 ### Ubuntu
 
-Our tests are implemented in `serverspec`, which relies on `ruby` and `rspec`. 
+Our tests are implemented in `serverspec`, which relies on `ruby` and `rspec`.
 
 #### Option 1: Build and Test scripts
 
@@ -54,12 +54,12 @@ Runs a build and test of the `windows.ltsc2019` container
 cd windows.ltsc2019
 docker build . -t worker-tools
 docker build . -t worker-tools-tests -f Tests.Dockerfile --build-arg ContainerUnderTest=worker-tools
-docker run -it -v ${pwd}:/app worker-tools-tests
+docker run -it -v ${pwd}:c:\app worker-tools-tests powershell
 ```
 
 Then within the running docker container
 
 ```powershell
-cd app\windows.ltsc2019 
+cd c:\app
 Invoke-Pester spec\windows.ltsc2019* -EnableExit
 ```

--- a/build.cake
+++ b/build.cake
@@ -171,7 +171,7 @@ Task("Test")
             var specPath = "spec\\";
             var appPath ="app\\";
             processSettings = new ProcessSettings{
-                Arguments = $"run -v {currentDirectory}:C:\\app {testContainerName} powershell -Command \"cd {appPath}{dockerTag.imageDirectory}; Invoke-Pester {specPath}{dockerTag.imageDirectory}* -EnableExit\""
+                Arguments = $"run -v {currentDirectory}:C:\\app {testContainerName} powershell -Command \"cd {appPath}{dockerTag.imageDirectory}; Invoke-Pester {specPath}{dockerTag.imageDirectory}* -OutputFile PesterTestResults.xml -OutputFormat NUnitXml -EnableExit\""
             };
         }
 

--- a/ubuntu.18.04/.rspec
+++ b/ubuntu.18.04/.rspec
@@ -1,2 +1,4 @@
 --color
 --format documentation
+--format RspecJunitFormatter
+--out rspec.xml

--- a/ubuntu.18.04/Dockerfile
+++ b/ubuntu.18.04/Dockerfile
@@ -1,24 +1,23 @@
 FROM ubuntu:18.04
 
-ARG Powershell_Version=7.0.0\*
-ARG Octopus_Cli_Version=7.3.2
-ARG Octopus_Client_Version=8.4.0
-ARG Azure_Cli_Version=2.4.0\*
-ARG Azure_Powershell_Version=2.2.0
-ARG Helm_Version=v3.2.4
+ARG Powershell_Version=7.0.3\*
+ARG Octopus_Cli_Version=7.4.1
+ARG Octopus_Client_Version=8.8.3
+ARG Azure_Cli_Version=2.10.1\*
+ARG Azure_Powershell_Version=4.5.0
+ARG Helm_Version=v3.3.0
 ARG Node_Version=12.18.3\*
-ARG Kubectl_Version=1.18.6-00
-ARG Terraform_Version=0.12.24
-ARG Eks_Cli_Version=0.23.0
-ARG Ecs_Cli_Version=1.18.1
-ARG Aws_Iam_Authenticator_Version=1.16.8
+ARG Kubectl_Version=1.18.8-00
+ARG Terraform_Version=0.13.0
+ARG Eks_Cli_Version=0.25.0
+ARG Ecs_Cli_Version=1.20.0
+ARG Aws_Iam_Authenticator_Version=1.17.9
 ARG Umoci_Version=0.4.6
 
 # get `wget` & software-properties-common
 # https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-linux?view=powershell-7#ubuntu-1804
-RUN apt-get update && \ 
-    apt-get install -y wget unzip apt-utils curl && \ 
-    apt-get install -y software-properties-common 
+RUN apt-get update && \
+    apt-get install -y wget unzip apt-utils curl software-properties-common
 
 # get powershell for 18.04
 RUN wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb && \
@@ -64,9 +63,9 @@ RUN apt-get install -y maven gradle
 
 # Get Azure CLI
 # https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-apt?view=azure-cli-latest
-RUN wget --quiet -O - https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null
-RUN echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ bionic main" | tee /etc/apt/sources.list.d/azure-cli.list
-RUN apt-get update && \
+RUN wget --quiet -O - https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null && \
+    echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ bionic main" | tee /etc/apt/sources.list.d/azure-cli.list && \
+    apt-get update && \
     apt-get install -y azure-cli=${Azure_Cli_Version}
 
 # Get NodeJS
@@ -76,9 +75,9 @@ RUN wget --quiet -O - https://deb.nodesource.com/setup_12.x | bash && \
 
 # Get Kubectl
 # https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-using-native-package-management
-RUN wget --quiet -O - https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-RUN echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list
-RUN apt-get update && apt-get install -y kubectl=${Kubectl_Version}
+RUN wget --quiet -O - https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -  && \
+    echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list && \
+    apt-get update && apt-get install -y kubectl=${Kubectl_Version}
 
 # Get Terraform
 # https://computingforgeeks.com/how-to-install-terraform-on-ubuntu-centos-7/
@@ -88,10 +87,10 @@ RUN wget https://releases.hashicorp.com/terraform/${Terraform_Version}/terraform
 
 # Install Google Cloud CLI
 # https://cloud.google.com/sdk/docs/downloads-apt-get
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-RUN apt-get install -y ca-certificates gnupg
-RUN wget -q -O - https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
-RUN apt-get update && apt-get install -y google-cloud-sdk
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    apt-get install -y ca-certificates gnupg && \
+    wget -q -O - https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
+    apt-get update && apt-get install -y google-cloud-sdk
 
 # Get python & groff
 RUN apt-get install -y python3-pip groff
@@ -112,7 +111,7 @@ RUN curl --silent --location "https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-li
 
 # Get AWS IAM Authneticator
 # https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html
-RUN curl --silent --location https://amazon-eks.s3.us-west-2.amazonaws.com/${Aws_Iam_Authenticator_Version}/2020-04-16/bin/linux/amd64/aws-iam-authenticator -o /usr/local/bin/aws-iam-authenticator && \
+RUN curl --silent --location https://amazon-eks.s3.us-west-2.amazonaws.com/${Aws_Iam_Authenticator_Version}/2020-08-04/bin/linux/amd64/aws-iam-authenticator -o /usr/local/bin/aws-iam-authenticator && \
     chmod +x /usr/local/bin/aws-iam-authenticator
 
 # Get the Istio CLI
@@ -135,11 +134,11 @@ RUN curl --silent --location https://github.com/opencontainers/umoci/releases/do
 # Get common utilities for scripting
 # https://mikefarah.gitbook.io/yq/
 # https://augeas.net/
-RUN add-apt-repository ppa:rmescandon/yq
-RUN apt-get update && apt-get install -y jq yq openssh-client rsync git augeas-tools
+RUN add-apt-repository -y ppa:rmescandon/yq && \
+    apt-get update && apt-get install -y jq yq openssh-client rsync git augeas-tools
 
 # Skopeo
 # https://github.com/containers/skopeo/blob/master/install.md
-RUN sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_18.04/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
-RUN wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_18.04/Release.key -O- | apt-key add -
-RUN apt-get update && apt-get install -y skopeo
+RUN sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_18.04/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list" && \
+    wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_18.04/Release.key -O- | apt-key add - && \
+    apt-get update && apt-get install -y skopeo

--- a/ubuntu.18.04/Dockerfile
+++ b/ubuntu.18.04/Dockerfile
@@ -109,7 +109,7 @@ RUN curl --silent --location "https://github.com/weaveworks/eksctl/releases/down
 RUN curl --silent --location "https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-linux-amd64-v${Ecs_Cli_Version}" -o /usr/local/bin/ecs-cli && \
     chmod +x /usr/local/bin/ecs-cli
 
-# Get AWS IAM Authneticator
+# Get AWS IAM Authenticator
 # https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html
 RUN curl --silent --location https://amazon-eks.s3.us-west-2.amazonaws.com/${Aws_Iam_Authenticator_Version}/2020-08-04/bin/linux/amd64/aws-iam-authenticator -o /usr/local/bin/aws-iam-authenticator && \
     chmod +x /usr/local/bin/aws-iam-authenticator

--- a/ubuntu.18.04/Dockerfile
+++ b/ubuntu.18.04/Dockerfile
@@ -11,7 +11,7 @@ ARG Kubectl_Version=1.18.8-00
 ARG Terraform_Version=0.13.0
 ARG Eks_Cli_Version=0.25.0
 ARG Ecs_Cli_Version=1.20.0
-ARG Aws_Iam_Authenticator_Version=1.17.9
+ARG Aws_Iam_Authenticator_Version=0.5.1
 ARG Umoci_Version=0.4.6
 
 # get `wget` & software-properties-common
@@ -111,7 +111,7 @@ RUN curl --silent --location "https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-li
 
 # Get AWS IAM Authenticator
 # https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html
-RUN curl --silent --location https://amazon-eks.s3.us-west-2.amazonaws.com/${Aws_Iam_Authenticator_Version}/2020-08-04/bin/linux/amd64/aws-iam-authenticator -o /usr/local/bin/aws-iam-authenticator && \
+RUN curl --silent --location https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${Aws_Iam_Authenticator_Version}/aws-iam-authenticator_${Aws_Iam_Authenticator_Version}_linux_amd64 -o /usr/local/bin/aws-iam-authenticator && \
     chmod +x /usr/local/bin/aws-iam-authenticator
 
 # Get the Istio CLI

--- a/ubuntu.18.04/spec/ubuntu.18.04_spec.rb
+++ b/ubuntu.18.04/spec/ubuntu.18.04_spec.rb
@@ -2,17 +2,22 @@ require 'spec_helper'
 
 describe command('pwsh --version') do
   its(:exit_status) { should eq(0) }
-  its(:stdout) { should contain(/PowerShell 7.0.0/) }
+  its(:stdout) { should contain(/PowerShell 7.0.3/) }
 end
 
 describe command("pwsh -c '[Reflection.AssemblyName]::GetAssemblyName(\"/Octopus.Client.dll\").Version.ToString()'") do
   its(:exit_status) { should eq(0) }
-  its(:stdout) { should contain(/8.4.0.0/) }
+  its(:stdout) { should contain(/8.8.3.0/) }
+end
+
+describe command("pwsh -c '(Get-Module Az -ListAvailable).Version.ToString()'") do
+  its(:exit_status) { should eq(0) }
+  its(:stdout) { should contain(/4.5.0/) }
 end
 
 describe command('dotnet --version') do
   its(:exit_status) { should eq(0) }
-  its(:stdout) { should contain(/3.1.302/) }
+  its(:stdout) { should contain(/3.1.401/) }
 end
 
 describe command('java --version') do
@@ -22,7 +27,7 @@ end
 
 describe command('az --version') do
   its(:exit_status) { should eq(0) }
-  its(:stdout) { should contain(/2.4.0/) }
+  its(:stdout) { should contain(/2.10.1/) }
 end
 
 describe command('aws --version') do
@@ -36,17 +41,17 @@ describe command('node --version') do
 end
 
 describe command('kubectl version') do
-  its(:stdout) { should contain(/v1.18.6/) }
+  its(:stdout) { should contain(/v1.18.8/) }
 end
 
 describe command("helm version") do
   its(:exit_status) { should eq(0) }
-  its(:stdout) { should contain(/v3.2.4/)}
+  its(:stdout) { should contain(/v3.3.0/)}
 end
 
 describe command("terraform version") do
   its(:exit_status) { should eq(0) }
-  its(:stdout) { should contain(/Terraform v0.12.24/)}
+  its(:stdout) { should contain(/Terraform v0.13.0/)}
 end
 
 describe "python" do
@@ -69,17 +74,17 @@ end
 
 describe command("octo --version") do
   its(:exit_status) { should eq(0) }
-  its(:stdout) { should contain(/7.3.2/)}
+  its(:stdout) { should contain(/7.4.1/)}
 end
 
 describe command("eksctl version") do
   its(:exit_status) { should eq(0) }
-  its(:stdout) { should contain(/0.23.0/)}
+  its(:stdout) { should contain(/0.25.0/)}
 end
 
 describe command("ecs-cli --version") do
   its(:exit_status) { should eq(0) }
-  its(:stdout) { should contain(/1.18.1/)}
+  its(:stdout) { should contain(/1.20.0/)}
 end
 
 describe command("mvn --version") do

--- a/ubuntu.18.04/spec/ubuntu.18.04_spec.rb
+++ b/ubuntu.18.04/spec/ubuntu.18.04_spec.rb
@@ -97,7 +97,7 @@ end
 
 describe command("aws-iam-authenticator version") do
   its(:exit_status) { should eq(0) }
-  its(:stdout) { should contain(/v0.5.1/)}
+  its(:stdout) { should contain(/0.5.1/)}
 end
 
 describe command("istioctl version") do

--- a/ubuntu.18.04/spec/ubuntu.18.04_spec.rb
+++ b/ubuntu.18.04/spec/ubuntu.18.04_spec.rb
@@ -97,7 +97,7 @@ end
 
 describe command("aws-iam-authenticator version") do
   its(:exit_status) { should eq(0) }
-  its(:stdout) { should contain(/v0.5.0/)}
+  its(:stdout) { should contain(/v0.5.1/)}
 end
 
 describe command("istioctl version") do

--- a/windows.ltsc2019/Dockerfile
+++ b/windows.ltsc2019/Dockerfile
@@ -66,10 +66,7 @@ RUN choco install scriptcs -y --version 0.17.1 --no-progress
 RUN choco install octopustools -y --version 7.4.1 --no-progress
 
 # # Install Octopus Client
-RUN Install-Package Octopus.Client -source https://www.nuget.org/api/v2 -SkipDependencies -Force -RequiredVersion 8.8.3 `
-    $path = Join-Path (Get-Item ((Get-Package Octopus.Client).source)).Directory.FullName "lib/net452/Octopus.Client.dll"; `
-    Add-Type -Path $path; `
-    echo $path;
+RUN Install-Package Octopus.Client -source https://www.nuget.org/api/v2 -SkipDependencies -Force -RequiredVersion 8.8.3
 
 # # Install eksctl
 RUN choco install eksctl -y --version 0.25.0 --no-progress

--- a/windows.ltsc2019/Dockerfile
+++ b/windows.ltsc2019/Dockerfile
@@ -1,70 +1,79 @@
 # escape=`
 
+#todo: change to (New-Object Net.WebClient).DownloadFile(url,dest)
+#todo: install pwsh
+
 FROM mcr.microsoft.com/windows/servercore:ltsc2019
 SHELL ["powershell", "-Command"]
 
 # Install Choco
-RUN Set-ExecutionPolicy Bypass -Scope Process -Force
-RUN [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
-RUN iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+RUN $ProgressPreference = 'SilentlyContinue'; `
+    Set-ExecutionPolicy Bypass -Scope Process -Force; `
+    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; `
+    iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 
 # Install dotnet 3+
-RUN Invoke-WebRequest 'https://dot.net/v1/dotnet-install.ps1' -outFile 'dotnet-install.ps1'
-RUN .\dotnet-install.ps1
-RUN rm dotnet-install.ps1
+RUN Invoke-WebRequest 'https://dot.net/v1/dotnet-install.ps1' -outFile 'dotnet-install.ps1'; `
+    .\dotnet-install.ps1; `
+    rm dotnet-install.ps1
 
 # Install JDK
-RUN choco install openjdk14 --allow-empty-checksums --yes --no-progress
-RUN refreshenv
+RUN choco install openjdk14 --allow-empty-checksums --yes --no-progress; refreshenv
 
 # Install Azure CLI
 # This currently isn't working, and I'm unsure why
 # https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-windows?view=azure-cli-latest
-RUN Invoke-WebRequest -Uri https://aka.ms/installazurecliwindows -OutFile .\AzureCLI.msi; Start-Process msiexec.exe -Wait -ArgumentList '/I AzureCLI.msi /quiet'; rm .\AzureCLI.msi
+RUN Invoke-WebRequest -Uri https://aka.ms/installazurecliwindows -OutFile .\AzureCLI.msi; `
+    Start-Process msiexec.exe -Wait -ArgumentList '/I AzureCLI.msi /quiet'; `
+    rm .\AzureCLI.msi
 
 # # Install AWS CLI
 # # https://docs.aws.amazon.com/powershell/latest/userguide/pstools-getting-set-up-windows.html#ps-installing-awspowershellnetcore
-RUN Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
-RUN Install-Module -name AWSPowerShell.NetCore -RequiredVersion 4.0.5 -Force
+RUN Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force; `
+    Install-Module -name AWSPowerShell.NetCore -RequiredVersion 4.0.6 -Force
 
 # # Install NodeJS
-RUN choco install nodejs-lts -y --version 12.16.2
+RUN choco install nodejs-lts -y --version 12.18.3 --no-progress
 
 # # Install kubectl
-RUN Invoke-WebRequest "https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/windows/amd64/kubectl.exe" -OutFile .\kubectl.exe;  mv .\kubectl.exe C:\Windows\system32\;
-
+RUN Invoke-WebRequest "https://storage.googleapis.com/kubernetes-release/release/v1.18.8/bin/windows/amd64/kubectl.exe" -OutFile .\kubectl.exe; `
+    mv .\kubectl.exe C:\Windows\system32\;
 
 # # Install helm 3
-RUN choco install -y kubernetes-helm --version 3.1.2
-
+RUN choco install -y kubernetes-helm --version 3.3.0 --no-progress
 
 # # Install Terraform
-RUN choco install -y terraform --version 0.12.24
+RUN choco install -y terraform --version 0.13.0 --no-progress
 
 # # Install python
-RUN choco install -y python3 --version 3.8.2
+RUN choco install -y python3 --version 3.8.5 --no-progress; `
+    refreshenv
 
 # # Install 7ZIP because gcloud
-RUN choco install 7zip -y --version 19.0
-# # Install gcloud
-RUN Invoke-WebRequest "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-289.0.0-windows-x86_64.zip" -OutFile google-cloud-sdk-289.0.0-windows-x86_64.zip;
+RUN choco install 7zip -y --version 19.0 --no-progress
 
-# # UNZIP AND INSTALL gcloud
-ADD .\scripts\update_path.cmd C:\update_path.cmd
-RUN  & '.\Program Files\7-Zip\7z.exe' x .\google-cloud-sdk-289.0.0-windows-x86_64.zip; .\google-cloud-sdk\install.bat --quiet; rm .\google-cloud-sdk-289.0.0-windows-x86_64.zip
+# # Install gcloud
+RUN Invoke-WebRequest "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-305.0.0-windows-x86_64.zip" -OutFile google-cloud-sdk-305.0.0-windows-x86_64.zip; `
+    # # UNZIP AND INSTALL gcloud
+    & '.\Program Files\7-Zip\7z.exe' x .\google-cloud-sdk-305.0.0-windows-x86_64.zip; `
+    .\google-cloud-sdk\install.bat --quiet; `
+    rm .\google-cloud-sdk-305.0.0-windows-x86_64.zip
 
 # # Install ScriptCS
-RUN choco install scriptcs -y --version 0.17.1
+RUN choco install scriptcs -y --version 0.17.1 --no-progress
 
 # # Install octo
-RUN choco install octopustools -y --version 7.3.4
+RUN choco install octopustools -y --version 7.4.1 --no-progress
 
 # # Install Octopus Client
-RUN Install-Package Octopus.Client -source https://www.nuget.org/api/v2 -SkipDependencies -Force -RequiredVersion 8.4.2
-RUN $path = Join-Path (Get-Item ((Get-Package Octopus.Client).source)).Directory.FullName "lib/net452/Octopus.Client.dll"; Add-Type -Path $path; echo $path;
+RUN Install-Package Octopus.Client -source https://www.nuget.org/api/v2 -SkipDependencies -Force -RequiredVersion 8.8.3 `
+    $path = Join-Path (Get-Item ((Get-Package Octopus.Client).source)).Directory.FullName "lib/net452/Octopus.Client.dll"; `
+    Add-Type -Path $path; `
+    echo $path;
 
 # # Install eksctl
-RUN choco install eksctl -y --version 0.23.0
+RUN choco install eksctl -y --version 0.25.0 --no-progress
 
 # # Update path for new tools
+ADD .\scripts\update_path.cmd C:\update_path.cmd
 RUN .\update_path.cmd;

--- a/windows.ltsc2019/Dockerfile
+++ b/windows.ltsc2019/Dockerfile
@@ -68,6 +68,9 @@ RUN Install-Package Octopus.Client -source https://www.nuget.org/api/v2 -SkipDep
 # # Install eksctl
 RUN choco install eksctl -y --version 0.25.0 --no-progress
 
+# # Install Powershell Core
+RUN choco install powershell-core --yes --version 7.0.3 --no-progress
+
 # # Update path for new tools
 ADD .\scripts\update_path.cmd C:\update_path.cmd
 RUN .\update_path.cmd;

--- a/windows.ltsc2019/Dockerfile
+++ b/windows.ltsc2019/Dockerfile
@@ -18,7 +18,6 @@ RUN Invoke-WebRequest 'https://dot.net/v1/dotnet-install.ps1' -outFile 'dotnet-i
 RUN choco install openjdk14 --allow-empty-checksums --yes --no-progress; refreshenv
 
 # Install Azure CLI
-# This currently isn't working, and I'm unsure why
 # https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-windows?view=azure-cli-latest
 RUN Invoke-WebRequest -Uri https://aka.ms/installazurecliwindows -OutFile .\AzureCLI.msi; `
     Start-Process msiexec.exe -Wait -ArgumentList '/I AzureCLI.msi /quiet'; `

--- a/windows.ltsc2019/Dockerfile
+++ b/windows.ltsc2019/Dockerfile
@@ -1,8 +1,5 @@
 # escape=`
 
-#todo: change to (New-Object Net.WebClient).DownloadFile(url,dest)
-#todo: install pwsh
-
 FROM mcr.microsoft.com/windows/servercore:ltsc2019
 SHELL ["powershell", "-Command"]
 

--- a/windows.ltsc2019/spec/windows.ltsc2019.tests.ps1
+++ b/windows.ltsc2019/spec/windows.ltsc2019.tests.ps1
@@ -82,6 +82,6 @@ Describe  'installed dependencies' {
     It 'should have installed powershell core' {
         $output = & pwsh --version
         $LASTEXITCODE | Should be 0
-        $output | Should -match '^PowerShell 7\.0\.3*'
+        $output | Should Match '^PowerShell 7\.0\.3*'
     }
 }

--- a/windows.ltsc2019/spec/windows.ltsc2019.tests.ps1
+++ b/windows.ltsc2019/spec/windows.ltsc2019.tests.ps1
@@ -15,18 +15,18 @@ Describe  'installed dependencies' {
 
     It 'has dotnet is installed' {
         dotnet --version | Should Match '3.1.401'
-        $LASTEXITCODE | Should -be 0
+        $LASTEXITCODE | Should be 0
     }
 
     It 'has java is installed' {
       java -version 2>&1 | Select-String -Pattern '14\.0\.2' | Should BeLike "*14.0.2*"
-      $LASTEXITCODE | Should -be 0
+      $LASTEXITCODE | Should be 0
     }
 
     It 'has az is installed' {
       $output = (& az version) | convertfrom-json
       $output.'azure-cli' | Should Be '2.10.1'
-      $LASTEXITCODE | Should -be 0
+      $LASTEXITCODE | Should be 0
     }
 
     It 'has aws is installed' {
@@ -35,53 +35,53 @@ Describe  'installed dependencies' {
 
     It 'has node is installed' {
         node --version | Should Match '12.18.3'
-        $LASTEXITCODE | Should -be 0
+        $LASTEXITCODE | Should be 0
     }
 
     It 'has kubectl is installed' {
         kubectl version --client | Should Match '1.18.8'
-        $LASTEXITCODE | Should -be 0
+        $LASTEXITCODE | Should be 0
     }
 
     It 'has helm is installed' {
         helm version | Should Match '3.3.0'
-        $LASTEXITCODE | Should -be 0
+        $LASTEXITCODE | Should be 0
     }
 
     It 'has terraform is installed' {
         terraform version | Should Match '0.13.0'
-        $LASTEXITCODE | Should -be 0
+        $LASTEXITCODE | Should be 0
     }
 
     It 'has python is installed' {
         python --version | Should Match '3.8.5'
-        $LASTEXITCODE | Should -be 0
+        $LASTEXITCODE | Should be 0
     }
 
     It 'has gcloud is installed' {
         gcloud --version | Select-String -Pattern "305.0.0" | Should BeLike "*305.0.0*"
-        $LASTEXITCODE | Should -be 0
+        $LASTEXITCODE | Should be 0
     }
 
     It 'has octo is installed' {
         octo --version | Should Match '7.4.1'
-        $LASTEXITCODE | Should -be 0
+        $LASTEXITCODE | Should be 0
     }
 
     It 'has eksctl is installed' {
         eksctl version | Should Match '0.25.0'
-        $LASTEXITCODE | Should -be 0
+        $LASTEXITCODE | Should be 0
     }
 
     It 'has 7zip installed' {
         $output = (& "C:\Program Files\7-Zip\7z.exe" --help) -join "`n"
         $output | Should Match '7-Zip 19.00'
-        $LASTEXITCODE | Should -be 0
+        $LASTEXITCODE | Should be 0
     }
 
     It 'should have installed powershell core' {
         $output = & pwsh --version
-        $LASTEXITCODE | Should -be 0
+        $LASTEXITCODE | Should be 0
         $output | Should -match '^PowerShell 7\.0\.3*'
     }
 }

--- a/windows.ltsc2019/spec/windows.ltsc2019.tests.ps1
+++ b/windows.ltsc2019/spec/windows.ltsc2019.tests.ps1
@@ -15,15 +15,18 @@ Describe  'installed dependencies' {
 
     It 'has dotnet is installed' {
         dotnet --version | Should Match '3.1.401'
+        $LASTEXITCODE | Should -be 0
     }
 
     It 'has java is installed' {
       java -version 2>&1 | Select-String -Pattern '14\.0\.2' | Should BeLike "*14.0.2*"
+      $LASTEXITCODE | Should -be 0
     }
 
     It 'has az is installed' {
       $output = (& az version) | convertfrom-json
       $output.'azure-cli' | Should Be '2.10.1'
+      $LASTEXITCODE | Should -be 0
     }
 
     It 'has aws is installed' {
@@ -32,38 +35,53 @@ Describe  'installed dependencies' {
 
     It 'has node is installed' {
         node --version | Should Match '12.18.3'
+        $LASTEXITCODE | Should -be 0
     }
 
     It 'has kubectl is installed' {
         kubectl version --client | Should Match '1.18.8'
+        $LASTEXITCODE | Should -be 0
     }
 
     It 'has helm is installed' {
         helm version | Should Match '3.3.0'
+        $LASTEXITCODE | Should -be 0
     }
 
     It 'has terraform is installed' {
         terraform version | Should Match '0.13.0'
+        $LASTEXITCODE | Should -be 0
     }
 
     It 'has python is installed' {
         python --version | Should Match '3.8.5'
+        $LASTEXITCODE | Should -be 0
     }
 
     It 'has gcloud is installed' {
         gcloud --version | Select-String -Pattern "305.0.0" | Should BeLike "*305.0.0*"
+        $LASTEXITCODE | Should -be 0
     }
 
     It 'has octo is installed' {
         octo --version | Should Match '7.4.1'
+        $LASTEXITCODE | Should -be 0
     }
 
     It 'has eksctl is installed' {
         eksctl version | Should Match '0.25.0'
+        $LASTEXITCODE | Should -be 0
     }
 
     It 'has 7zip installed' {
-      $output = (& "C:\Program Files\7-Zip\7z.exe" --help) -join "`n"
-      $output | Should Match '7-Zip 19.00'
-  }
+        $output = (& "C:\Program Files\7-Zip\7z.exe" --help) -join "`n"
+        $output | Should Match '7-Zip 19.00'
+        $LASTEXITCODE | Should -be 0
+    }
+
+    It 'should have installed powershell core' {
+        $output = & pwsh --version
+        $LASTEXITCODE | Should -be 0
+        $output | Should -match '^PowerShell 7\.0\.3*'
+    }
 }

--- a/windows.ltsc2019/spec/windows.ltsc2019.tests.ps1
+++ b/windows.ltsc2019/spec/windows.ltsc2019.tests.ps1
@@ -10,11 +10,11 @@ Describe  'installed dependencies' {
     }
 
     It 'has Octopus.Client is installed ' {
-      [Reflection.AssemblyName]::GetAssemblyName("C:\Program Files\PackageManagement\NuGet\Packages\Octopus.Client.8.4.2\lib\net452\Octopus.Client.dll").Version.ToString() | Should Match '8.4.2.0'
+      [Reflection.AssemblyName]::GetAssemblyName("C:\Program Files\PackageManagement\NuGet\Packages\Octopus.Client.8.8.3\lib\net452\Octopus.Client.dll").Version.ToString() | Should Match '8.8.3.0'
     }
 
     It 'has dotnet is installed' {
-        dotnet --version | Should Match '3.1.302'
+        dotnet --version | Should Match '3.1.401'
     }
 
     It 'has java is installed' {
@@ -26,11 +26,11 @@ Describe  'installed dependencies' {
     }
 
     It 'has aws is installed' {
-      Get-AWSPowerShellVersion | Should Match '4.0.5'
+      Get-AWSPowerShellVersion | Should Match '4.0.6'
     }
 
     It 'has node is installed' {
-        node --version | Should Match '12.16.2'
+        node --version | Should Match '12.18.3'
     }
 
     It 'has kubectl is installed' {
@@ -38,26 +38,30 @@ Describe  'installed dependencies' {
     }
 
     It 'has helm is installed' {
-        helm version | Should Match '3.1.2'
+        helm version | Should Match '3.3.0'
     }
 
     It 'has terraform is installed' {
-        terraform version | Should Match '0.12.24'
+        terraform version | Should Match '0.13.0'
     }
 
     It 'has python is installed' {
-        python --version | Should Match '3.8.2'
+        python --version | Should Match '3.8.5'
     }
 
     It 'has gcloud is installed' {
-      gcloud --version | Select-String -Pattern "289.0.0" | Should BeLike "*289.0.0*"
+        gcloud --version | Select-String -Pattern "305.0.0" | Should BeLike "*305.0.0*"
     }
 
     It 'has octo is installed' {
-        octo --version | Should Match '7.3.4'
+        octo --version | Should Match '7.4.1'
     }
 
     It 'has eksctl is installed' {
-        eksctl version | Should Match '0.23.0'
+        eksctl version | Should Match '0.25.0'
     }
+
+    It 'has 7zip installed' {
+      & ".\Program Files\7-Zip\7z.exe" --help | Should Match '7-Zip 19.00'
+  }
 }

--- a/windows.ltsc2019/spec/windows.ltsc2019.tests.ps1
+++ b/windows.ltsc2019/spec/windows.ltsc2019.tests.ps1
@@ -3,72 +3,72 @@ $pesterModules = @( Get-Module -Name "Pester" -ErrorAction "SilentlyContinue" );
 Write-Host 'Running tests with Pester v'+$($pesterModules[0].Version)
 
 Describe  'installed dependencies' {
-    It 'has powershell is installed' {
+    It 'has powershell installed' {
         $PSVersionTable.PSVersion.ToString() | Should Match '5.1.17763'
     }
 
-    It 'has Octopus.Client is installed ' {
+    It 'has Octopus.Client installed ' {
         $expectedVersion = "8.8.3"
         Test-Path "C:\Program Files\PackageManagement\NuGet\Packages\Octopus.Client.$expectedVersion\lib\net452\Octopus.Client.dll" | Should Be $true
         [Reflection.AssemblyName]::GetAssemblyName("C:\Program Files\PackageManagement\NuGet\Packages\Octopus.Client.$expectedVersion\lib\net452\Octopus.Client.dll").Version.ToString() | Should Match "$expectedVersion.0"
     }
 
-    It 'has dotnet is installed' {
+    It 'has dotnet installed' {
         dotnet --version | Should Match '3.1.401'
         $LASTEXITCODE | Should be 0
     }
 
-    It 'has java is installed' {
+    It 'has java installed' {
       java -version 2>&1 | Select-String -Pattern '14\.0\.2' | Should BeLike "*14.0.2*"
       $LASTEXITCODE | Should be 0
     }
 
-    It 'has az is installed' {
+    It 'has az installed' {
       $output = (& az version) | convertfrom-json
       $output.'azure-cli' | Should Be '2.10.1'
       $LASTEXITCODE | Should be 0
     }
 
-    It 'has aws is installed' {
+    It 'has aws powershell installed' {
       Get-AWSPowerShellVersion | Should Match '4.0.6'
     }
 
-    It 'has node is installed' {
+    It 'has node installed' {
         node --version | Should Match '12.18.3'
         $LASTEXITCODE | Should be 0
     }
 
-    It 'has kubectl is installed' {
+    It 'has kubectl installed' {
         kubectl version --client | Should Match '1.18.8'
         $LASTEXITCODE | Should be 0
     }
 
-    It 'has helm is installed' {
+    It 'has helm installed' {
         helm version | Should Match '3.3.0'
         $LASTEXITCODE | Should be 0
     }
 
-    It 'has terraform is installed' {
+    It 'has terraform installed' {
         terraform version | Should Match '0.13.0'
         $LASTEXITCODE | Should be 0
     }
 
-    It 'has python is installed' {
+    It 'has python installed' {
         python --version | Should Match '3.8.5'
         $LASTEXITCODE | Should be 0
     }
 
-    It 'has gcloud is installed' {
+    It 'has gcloud installed' {
         gcloud --version | Select-String -Pattern "305.0.0" | Should BeLike "*305.0.0*"
         $LASTEXITCODE | Should be 0
     }
 
-    It 'has octo is installed' {
+    It 'has octo installed' {
         octo --version | Should Match '7.4.1'
         $LASTEXITCODE | Should be 0
     }
 
-    It 'has eksctl is installed' {
+    It 'has eksctl installed' {
         eksctl version | Should Match '0.25.0'
         $LASTEXITCODE | Should be 0
     }

--- a/windows.ltsc2019/spec/windows.ltsc2019.tests.ps1
+++ b/windows.ltsc2019/spec/windows.ltsc2019.tests.ps1
@@ -2,15 +2,15 @@ $pesterModules = @( Get-Module -Name "Pester" -ErrorAction "SilentlyContinue" );
 
 Write-Host 'Running tests with Pester v'+$($pesterModules[0].Version)
 
-$PowershellVersion = '5.1.17763';
-
 Describe  'installed dependencies' {
-    It 'has powershell $PowershellVersion is installed' {
-        $PSVersionTable.PSVersion.ToString() | Should Match $PowershellVersion
+    It 'has powershell is installed' {
+        $PSVersionTable.PSVersion.ToString() | Should Match '5.1.17763'
     }
 
     It 'has Octopus.Client is installed ' {
-      [Reflection.AssemblyName]::GetAssemblyName("C:\Program Files\PackageManagement\NuGet\Packages\Octopus.Client.8.8.3\lib\net452\Octopus.Client.dll").Version.ToString() | Should Match '8.8.3.0'
+        $expectedVersion = "8.8.3"
+        Test-Path "C:\Program Files\PackageManagement\NuGet\Packages\Octopus.Client.$expectedVersion\lib\net452\Octopus.Client.dll" | Should Be $true
+        [Reflection.AssemblyName]::GetAssemblyName("C:\Program Files\PackageManagement\NuGet\Packages\Octopus.Client.$expectedVersion\lib\net452\Octopus.Client.dll").Version.ToString() | Should Match "$expectedVersion.0"
     }
 
     It 'has dotnet is installed' {
@@ -22,7 +22,8 @@ Describe  'installed dependencies' {
     }
 
     It 'has az is installed' {
-      az version | Select-String -Pattern '2.4.0' | Should Match '2.4.0'
+      $output = (& az version) | convertfrom-json
+      $output.'azure-cli' | Should Be '2.10.1'
     }
 
     It 'has aws is installed' {
@@ -34,7 +35,7 @@ Describe  'installed dependencies' {
     }
 
     It 'has kubectl is installed' {
-        kubectl version --client | Should Match '1.18.0'
+        kubectl version --client | Should Match '1.18.8'
     }
 
     It 'has helm is installed' {
@@ -62,6 +63,7 @@ Describe  'installed dependencies' {
     }
 
     It 'has 7zip installed' {
-      & ".\Program Files\7-Zip\7z.exe" --help | Should Match '7-Zip 19.00'
+      $output = (& "C:\Program Files\7-Zip\7z.exe" --help) -join "`n"
+      $output | Should Match '7-Zip 19.00'
   }
 }


### PR DESCRIPTION
The dynamic worker vm images project has prompted a need for the worker images to be brought up to date, so we can really get value from the execution container images project.

This PR bumps the following dependencies

## Ubuntu:
* pwsh from `7.0.0` to `7.0.3
* OctopusCli from `7.3.2` to `7.4.1`
* OctopusClient from `8.4.0` to `8.8.3`
* Azure CLI from `2.4.0` to `2.10.1`
* Azure Powershell from `2.2.0` to `4.5.0`
* Helm from `3.2.4` to 3.3.0
* Kubectl from `1.18.6` to `1.18.8`
* Terraform from `0.12.24` to `0.13.0`
* EKS CLI from `0.23.0` to `0.25.0`
* ECS CLI from `1.18.1` to `1.20.0`
* dotnet core from `3.1.302` to `3.1.401`

## Windows:
* AWSPowerShell.NetCore from `4.0.5` to `4.0.6`
* OctopusCli from `7.3.4` to `7.4.1`
* OctopusClient from `8.4.2` to `8.8.3`
* node from `12.16.2` to `12.18.3`
* Kubectl from `1.18.6` to `1.18.8`
* Helm from `3.2.4` to 3.3.0
* Terraform from `0.12.24` to `0.13.0`
* gcloud sdk from `289.0.0` to `305.0.0`
* EKS CLI from `0.23.0` to `0.25.0`
* dotnet core from `3.1.302` to `3.1.401`