### PR TITLE
Bump to Ubuntu 20.04

### DIFF
--- a/ubuntu.20.04/Dockerfile
+++ b/ubuntu.20.04/Dockerfile
@@ -1,0 +1,158 @@
+FROM ubuntu:20.04
+
+ARG Aws_Cli_Version=2.0.60
+ARG Aws_Iam_Authenticator_Version=0.5.3
+ARG Aws_Powershell_Version=4.1.2
+ARG Azure_Cli_Version=2.14.0\*
+ARG Azure_Powershell_Version=4.5.0
+ARG Dotnet_Sdk_Version=3.1.401-1
+ARG Ecs_Cli_Version=1.20.0
+ARG Eks_Cli_Version=0.25.0
+ARG Google_Cloud_Cli_Version=339.0.0-0
+ARG Helm_Version=v3.7.1
+ARG Java_Jdk_Version=11.0.14+9-0ubuntu2~20.04
+ARG Kubectl_Version=1.18.8-00
+ARG Octopus_Cli_Version=7.4.1
+ARG Octopus_Client_Version=8.8.3
+ARG Powershell_Version=7.0.6\*
+ARG Terraform_Version=1.1.3
+ARG Umoci_Version=0.4.6
+
+# get `wget` & software-properties-common
+# https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-linux?view=powershell-7#ubuntu-1804
+RUN apt-get update && \
+    apt-get install -y wget unzip apt-utils curl software-properties-common
+
+# get powershell for 18.04
+RUN wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb && \
+    dpkg -i packages-microsoft-prod.deb && \
+    apt-get update && \
+    add-apt-repository universe && \
+    apt-get install -y powershell=${Powershell_Version}
+
+# Get Octo CLI
+# https://octopus.com/downloads/octopuscli#linux
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gnupg curl ca-certificates apt-transport-https && \
+    curl -sSfL https://apt.octopus.com/public.key | apt-key add - && \
+    sh -c "echo deb https://apt.octopus.com/ stable main > /etc/apt/sources.list.d/octopus.com.list" && \
+    apt-get update && \
+    apt-get install -y octopuscli=${Octopus_Cli_Version}
+
+# Install Octopus Client
+# https://octopus.com/docs/octopus-rest-api/octopus.client
+RUN pwsh -c 'Install-Package -Force Octopus.Client -MaximumVersion "'${Octopus_Client_Version}'" -source https://www.nuget.org/api/v2 -SkipDependencies' && \
+    octopusClientPackagePath=$(pwsh -c '(Get-Item ((Get-Package Octopus.Client).source)).Directory.FullName') && \
+    cp -r $octopusClientPackagePath/lib/netstandard2.0/* .
+
+# Get AWS Powershell core modules
+# https://docs.aws.amazon.com/powershell/latest/userguide/pstools-getting-set-up-linux-mac.html
+RUN pwsh -c 'Install-Module -Force -Name AWSPowerShell.NetCore -AllowClobber -Scope AllUsers -MaximumVersion "'${Aws_Powershell_Version}'"'
+
+# Get AZ Powershell core modules
+# https://docs.microsoft.com/en-us/powershell/azure/install-az-ps?view=azps-3.6.1
+RUN pwsh -c 'Install-Module -Force -Name Az -AllowClobber -Scope AllUsers -MaximumVersion "'${Azure_Powershell_Version}'"'
+
+# Get Helm3
+RUN wget --quiet -O - https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash -s -- -v ${Helm_Version}
+
+# Get .NET SDK 3.1
+# https://docs.microsoft.com/en-us/dotnet/core/install/linux-package-manager-ubuntu-1804
+RUN DOTNET_CLI_TELEMETRY_OPTOUT=1 && \
+    echo "export DOTNET_CLI_TELEMETRY_OPTOUT=1" > /etc/profile.d/set-dotnet-env-vars.sh && \
+    apt-get install -y apt-transport-https && \
+    apt-get update && \
+    apt-get install -y dotnet-sdk-3.1
+
+# Get JDK
+# https://www.digitalocean.com/community/tutorials/how-to-install-java-with-apt-on-ubuntu-18-04
+RUN apt-get install -y openjdk-11-jdk-headless=${Java_Jdk_Version}
+
+# Install common Java tools
+RUN apt-get install -y maven gradle
+
+# Get Azure CLI
+# https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-apt?view=azure-cli-latest
+RUN wget --quiet -O - https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null && \
+    echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ bionic main" | tee /etc/apt/sources.list.d/azure-cli.list && \
+    apt-get update && \
+    apt-get install -y azure-cli=${Azure_Cli_Version}
+
+# Get NodeJS
+# https://websiteforstudents.com/how-to-install-node-js-10-11-12-on-ubuntu-16-04-18-04-via-apt-and-snap/\
+RUN wget --quiet -O - https://deb.nodesource.com/setup_14.x | bash && \
+    apt-get install -y nodejs
+
+# Get Kubectl
+# https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-using-native-package-management
+RUN wget --quiet -O - https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -  && \
+    echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list && \
+    apt-get update && apt-get install -y kubectl=${Kubectl_Version}
+
+# Get Terraform
+# https://computingforgeeks.com/how-to-install-terraform-on-ubuntu-centos-7/
+RUN wget https://releases.hashicorp.com/terraform/${Terraform_Version}/terraform_${Terraform_Version}_linux_amd64.zip && \
+    unzip terraform_${Terraform_Version}_linux_amd64.zip && \
+    mv terraform /usr/local/bin
+
+# Install Google Cloud CLI
+# https://cloud.google.com/sdk/docs/downloads-apt-get
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    apt-get install -y ca-certificates gnupg && \
+    wget -q -O - https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
+    apt-get update && apt-get install -y google-cloud-sdk=${Google_Cloud_Cli_Version}
+
+# Get python & groff
+RUN apt-get install -y python3-pip groff
+
+# Get AWS CLI
+# https://docs.aws.amazon.com/cli/latest/userguide/install-linux.html#install-linux-awscli
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${Aws_Cli_Version}.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm awscliv2.zip && \
+    rm -rf ./aws
+
+# Get EKS CLI
+# https://github.com/weaveworks/eksctl
+RUN curl --silent --location "https://github.com/weaveworks/eksctl/releases/download/${Eks_Cli_Version}/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp && \
+    mv /tmp/eksctl /usr/local/bin
+
+# Get ECS CLI
+# https://github.com/aws/amazon-ecs-cli
+RUN curl --silent --location "https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-linux-amd64-v${Ecs_Cli_Version}" -o /usr/local/bin/ecs-cli && \
+    chmod +x /usr/local/bin/ecs-cli
+
+# Get AWS IAM Authenticator
+# https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html
+RUN curl --silent --location https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${Aws_Iam_Authenticator_Version}/aws-iam-authenticator_${Aws_Iam_Authenticator_Version}_linux_amd64 -o /usr/local/bin/aws-iam-authenticator && \
+    chmod +x /usr/local/bin/aws-iam-authenticator
+
+# Get the Istio CLI
+# https://istio.io/docs/ops/diagnostic-tools/istioctl/
+RUN curl -sL https://istio.io/downloadIstioctl | sh - && \
+    mv /root/.istioctl/bin/istioctl /usr/local/bin/istioctl && \
+    rm -rf /root/.istioctl
+
+# Get the Linkerd CLI
+# https://linkerd.io/2/getting-started/
+RUN curl -sL https://run.linkerd.io/install | sh && \
+    cp /root/.linkerd2/bin/linkerd /usr/local/bin && \
+    rm -rf /root/.linkerd2
+
+# Get tools for working with Docker images without the Docker daemon
+# https://github.com/openSUSE/umoci
+RUN curl --silent --location https://github.com/opencontainers/umoci/releases/download/v${Umoci_Version}/umoci.amd64 -o /usr/local/bin/umoci && \
+    chmod +x /usr/local/bin/umoci
+
+# Get common utilities for scripting
+# https://mikefarah.gitbook.io/yq/
+# https://augeas.net/
+RUN add-apt-repository -y ppa:rmescandon/yq && \
+    apt-get update && apt-get install -y jq yq openssh-client rsync git augeas-tools
+
+# Skopeo
+# https://github.com/containers/skopeo/blob/master/install.md
+RUN sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_18.04/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list" && \
+    wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_18.04/Release.key -O- | apt-key add - && \
+    apt-get update && apt-get install -y skopeo

--- a/ubuntu.20.04/Tests.Dockerfile
+++ b/ubuntu.20.04/Tests.Dockerfile
@@ -1,0 +1,4 @@
+ARG ContainerUnderTest=octopusdeploy/worker-tools
+
+FROM ${ContainerUnderTest}
+SHELL ["pwsh", "-Command"]

--- a/ubuntu.20.04/scripts/run-tests.ps1
+++ b/ubuntu.20.04/scripts/run-tests.ps1
@@ -1,0 +1,21 @@
+Write-Output "##teamcity[blockOpened name='Pester tests']"
+
+try {
+    Install-Module -Name "Pester" -MinimumVersion "5.0.2" -Force
+
+    Import-Module -Name "Pester"
+
+    Set-Location /app/ubuntu.20.04/spec
+
+    Write-Output "Running Pester Tests"
+    $configuration = [PesterConfiguration]::Default
+    $configuration.TestResult.Enabled = $true
+    $configuration.TestResult.OutputPath = '/app/ubuntu.20.04/spec/PesterTestResults.xml'
+    $configuration.TestResult.OutputFormat = 'NUnitXml'
+    $configuration.Run.PassThru = $true
+
+    Invoke-Pester -configuration $configuration
+} catch {
+    exit 1
+}
+Write-Output "##teamcity[blockClosed name='Pester tests']"

--- a/ubuntu.20.04/spec/ubuntu.20.04.tests.ps1
+++ b/ubuntu.20.04/spec/ubuntu.20.04.tests.ps1
@@ -1,0 +1,134 @@
+$ErrorActionPreference = "Continue"
+
+Install-Module Pester -Force
+Import-Module Pester
+
+$pesterModules = @( Get-Module -Name "Pester");
+Write-Host 'Running tests with Pester v'+$($pesterModules[0].Version)
+
+Describe  'installed dependencies' {
+    It 'has Octopus.Client installed ' {
+        $expectedVersion = "8.8.3"
+        [Reflection.AssemblyName]::GetAssemblyName("/Octopus.Client.dll").Version.ToString() | Should -match "$expectedVersion.0"
+    }
+
+    It 'has dotnet installed' {
+        dotnet --version | Should -match '3.1.\d+'
+        $LASTEXITCODE | Should -be 0
+    }
+
+    It 'has java installed' {
+        java --version | Should -beLike "*11.0.14*"
+        $LASTEXITCODE | Should -be 0
+    }
+
+    It 'has aws powershell module installed' {
+        (Get-Module AWSPowerShell.NetCore -ListAvailable).Version.ToString() | should -be '4.1.2.0'
+    }
+
+    It 'has az installed' {
+      $output = (& az version) | convertfrom-json
+      $output.'azure-cli' | Should -be '2.14.0'
+      $LASTEXITCODE | Should -be 0
+    }
+
+    It 'has az powershell module installed' {
+        (Get-Module Az -ListAvailable).Version.ToString() | should -be '4.5.0'
+    }
+
+    It 'has aws cli installed' {
+      aws --version 2>&1 | Should -match '2.0.60'
+    }
+
+    It 'has node installed' {
+        node --version | Should -match '14.\d+.\d+'
+        $LASTEXITCODE | Should -be 0
+    }
+
+    It 'has kubectl installed' {
+        kubectl version --client | Should -match '1.18.8'
+        $LASTEXITCODE | Should -be 0
+    }
+
+    It 'has helm installed' {
+        helm version | Should -match '3.7.1'
+        $LASTEXITCODE | Should -be 0
+    }
+
+    # If the terraform version is not the latest, then `terraform version` returns multiple lines and a non-zero return code
+    It 'has terraform installed' {
+        terraform version | Select-Object -First 1 | Should -match '1.1.3'
+    }
+
+    It 'has python3 installed' {
+        python3 --version | Should -match '3.6.9'
+        $LASTEXITCODE | Should -be 0
+    }
+
+    It 'has python2 installed' {
+        # python 2 prints it's version to stderr, for some reason
+        python --version 2>&1 | Should -match 'Python 2.7.17'
+        $LASTEXITCODE | Should -be 0
+    }
+
+    It 'has gcloud installed' {
+        gcloud --version | Select -First 1 | Should -be 'Google Cloud SDK 339.0.0'
+        $LASTEXITCODE | Should -be 0
+    }
+
+    It 'has octo installed' {
+        octo --version | Should -match '7.4.1'
+        $LASTEXITCODE | Should -be 0
+    }
+
+    It 'has eksctl installed' {
+        eksctl version | Should -match '0.25.0'
+        $LASTEXITCODE | Should -be 0
+    }
+
+    It 'has ecs-cli installed' {
+        ecs-cli --version | Should -match '1.20.0'
+        $LASTEXITCODE | Should -be 0
+    }
+
+    It 'has mvn installed' {
+        mvn --version | out-null
+        $LASTEXITCODE | Should -be 0
+    }
+
+    It 'has gradle installed' {
+        gradle --version | out-null
+        $LASTEXITCODE | Should -be 0
+    }
+
+    It 'has aws-iam-authenticator installed' {
+        aws-iam-authenticator version | out-null
+        $LASTEXITCODE | Should -be 0
+    }
+
+    It 'has istioctl installed' {
+        istioctl version | out-null
+        $LASTEXITCODE | Should -be 0
+    }
+
+    It 'has linkerd installed' {
+        linkerd version --client | out-null
+        $LASTEXITCODE | Should -be 0
+    }
+
+    It 'has skopeo installed' {
+        skopeo --version | out-null
+        $LASTEXITCODE | Should -be 0
+    }
+
+    It 'has umoci installed' {
+        umoci --version | out-null
+        $LASTEXITCODE | Should -be 0
+    }
+
+    It 'should have installed powershell core' {
+        $output = & pwsh --version
+        $LASTEXITCODE | Should -be 0
+        $output | Should -match '^PowerShell 7\.0\.6*'
+    }
+}


### PR DESCRIPTION
Due to some VPN issues I'm unable to run the tests locally. So although I think this works I'm unable to verify.

I'm running into ```/lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found``` when running a go cli on 18.04 and updating to 20.04 fixes it.