### PR TITLE
Change pipleine to push to our staging artifactory over dockerhub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 !/tools/packages.config
 /build/**
 /**/PesterTestResults.xml
+.idea

--- a/build.cake
+++ b/build.cake
@@ -49,7 +49,7 @@ class OctopusDockerTag
 Context.Log.Verbosity = Argument("Verbosity", Verbosity.Normal);
 
 var target = Argument("target", "Default");
-var dockerNamespace = Argument("docker-namespace", "octopusdeploy/worker-tools");
+var dockerNamespace = Argument("docker-namespace", "packages.octopushq.com/artifactory/docker-local/octopusdeploy/workertools");
 var imageDirectory = Argument("image-directory", "ubuntu.18.04");
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -186,21 +186,22 @@ Task("Test")
     }
     catch (Exception e)
     {
-        Information(e);
         throw; // rethrow the exception so cake will fail
+    } finally {
+        
     }
 });
 
-Task("Push")
+Task("Push to Artifactory")
     .IsDependentOn("Build")
     .IsDependentOn("Test")
     .Does(() =>
 {
     try
     {
-        Information("Releasing image to Docker Hub");
+        Information("Releasing image to Artifactory");
         dockerTag.Tags().ToList().ForEach((tag) => {
-            Information("Releasing image to Docker Hub");
+            Information("Releasing image to Artifactory");
             using(var process = StartAndReturnProcess("docker", new ProcessSettings{ Arguments = $"push {tag}" }))
             {
                 process.WaitForExit();

--- a/build.cake
+++ b/build.cake
@@ -49,7 +49,7 @@ class OctopusDockerTag
 Context.Log.Verbosity = Argument("Verbosity", Verbosity.Normal);
 
 var target = Argument("target", "Default");
-var dockerNamespace = Argument("docker-namespace", "packages.octopushq.com/artifactory/docker-local/octopusdeploy/workertools");
+var dockerNamespace = Argument("docker-namespace", "packages.octopushq.com/artifactory/docker-local/octopusdeploy/worker-tools");
 var imageDirectory = Argument("image-directory", "ubuntu.18.04");
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/build.ps1
+++ b/build.ps1
@@ -47,7 +47,7 @@ Param(
     [string]$Script = "build.cake",
     [string]$Target = "Default",
     [string]$ImageDirectory = "windows.ltsc2019",
-    [string]$DockerNamespace = "octopusdeploy/worker-tools",
+    [string]$DockerNamespace = "packages.octopushq.com/artifactory/docker-local/octopusdeploy/workertools",
     [ValidateSet("Release", "Debug")]
     [string]$Configuration = "Release",
     [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]

--- a/build.ps1
+++ b/build.ps1
@@ -47,7 +47,7 @@ Param(
     [string]$Script = "build.cake",
     [string]$Target = "Default",
     [string]$ImageDirectory = "windows.ltsc2019",
-    [string]$DockerNamespace = "packages.octopushq.com/artifactory/docker-local/octopusdeploy/workertools",
+    [string]$DockerNamespace = "packages.octopushq.com/artifactory/docker-local/octopusdeploy/worker-tools",
     [ValidateSet("Release", "Debug")]
     [string]$Configuration = "Release",
     [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]

--- a/ubuntu.18.04/Dockerfile
+++ b/ubuntu.18.04/Dockerfile
@@ -10,11 +10,11 @@ ARG Ecs_Cli_Version=1.20.0
 ARG Eks_Cli_Version=0.25.0
 ARG Google_Cloud_Cli_Version=339.0.0-0
 ARG Helm_Version=v3.7.1
-ARG Java_Jdk_Version=11.0.13+8-0ubuntu1~18.04
+ARG Java_Jdk_Version=11.0.15+10-0ubuntu0.18.04.1
 ARG Kubectl_Version=1.18.8-00
 ARG Octopus_Cli_Version=7.4.1
 ARG Octopus_Client_Version=8.8.3
-ARG Powershell_Version=7.0.6\*
+ARG Powershell_Version=7.0.10\*
 ARG Terraform_Version=1.1.3
 ARG Umoci_Version=0.4.6
 

--- a/ubuntu.18.04/spec/ubuntu.18.04.tests.ps1
+++ b/ubuntu.18.04/spec/ubuntu.18.04.tests.ps1
@@ -18,7 +18,7 @@ Describe  'installed dependencies' {
     }
 
     It 'has java installed' {
-        java --version | Should -beLike "*11.0.13*"
+        java --version | Should -beLike "*11.0.15*"
         $LASTEXITCODE | Should -be 0
     }
 


### PR DESCRIPTION
This change is to modify the existing pipeline to push to a staging environment (artifactory) as opposed to the production environment (dockerhub).

This would allow us to enable the pipeline and create a promotion process from staging to a production environment.

In this PR:
* Pushes to a (staging) artifactory rather than dockerhub
* Updates powershell and openjdk versions