### PR TITLE
Remove ubuntu config as code to cater for multiple projects

### DIFF
--- a/.octopus/deployment_settings.ocl
+++ b/.octopus/deployment_settings.ocl
@@ -1,7 +1,0 @@
-connectivity_policy {
-    allow_deployments_to_no_targets = true
-}
-
-versioning_strategy {
-    template = "#{Octopus.Version.LastMajor}.#{Octopus.Version.LastMinor}.#{Octopus.Version.NextPatch}"
-}

--- a/.octopus/schema_version.ocl
+++ b/.octopus/schema_version.ocl
@@ -1,1 +1,0 @@
-version = 3


### PR DESCRIPTION
Removing this temporarily, as we want to have multiple config-as-code projects.