### PR TITLE
Add OctoRelease step to cake, add argument options to scripts

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -21,6 +21,12 @@ The directory with the Dockerfile to build.
 The docker namespace to use to build and publish the image.
 .PARAMETER DockerNamespace
 The build script target to run.
+.PARAMETER OctopusServerUrl
+Octopus server url to create a release for.
+.PARAMETER OctopusApiKey
+Octopus server API Key.
+.PARAMETER OctopusProjectName
+The octopus project name to create a release on.
 .PARAMETER Configuration
 The build configuration to use.
 .PARAMETER Verbosity
@@ -48,6 +54,9 @@ Param(
     [string]$Target = "Default",
     [string]$ImageDirectory = "windows.ltsc2019",
     [string]$DockerNamespace = "docker.packages.octopushq.com/octopusdeploy/worker-tools",
+    [string]$OctopusServerUrl,
+    [string]$OctopusApiKey,
+    [string]$OctopusProjectName,
     [ValidateSet("Release", "Debug")]
     [string]$Configuration = "Release",
     [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
@@ -193,5 +202,5 @@ if (!(Test-Path $CAKE_EXE)) {
 
 # Start Cake
 Write-Host "Running build script..."
-Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" -image-directory=`"$ImageDirectory`" -docker-namespace=`"$DockerNamespace`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" -signing_certificate_path=`"$SigningCertificatePath`" -signing_certificate_password=`"$SigningCertificatePassword`" $UseMono $UseDryRun $UseExperimental $ScriptArgs"
+Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" -image-directory=`"$ImageDirectory`" -docker-namespace=`"$DockerNamespace`" -octopus-server-url=`"$OctopusServerUrl`" -octopus-api-key=`"$OctopusApiKey`" -octopus-project-name=`"$OctopusProjectName`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" -signing_certificate_path=`"$SigningCertificatePath`" -signing_certificate_password=`"$SigningCertificatePassword`" $UseMono $UseDryRun $UseExperimental $ScriptArgs"
 exit $LASTEXITCODE

--- a/build.sh
+++ b/build.sh
@@ -29,6 +29,9 @@ CONFIGURATION="Release"
 VERBOSITY="verbose"
 IMAGEDIRECTORY="ubuntu.18.04"
 DOCKERNAMESPACE="docker.packages.octopushq.com/octopusdeploy/worker-tools"
+OCTOPUSSERVERURL=
+OCTOPUSAPIKEY=
+OCTOPUSPROJECTNAME=
 DRYRUN=
 SHOW_VERSION=false
 SCRIPT_ARGUMENTS=()
@@ -42,6 +45,9 @@ for i in "$@"; do
         -v|--verbosity) VERBOSITY="$2"; shift ;;
         -id|--image-directory) IMAGEDIRECTORY="$2"; shift ;;
         -dn|--docker-namespace) DOCKERNAMESPACE="$2"; shift ;;
+        --octopus-server-url) OCTOPUSSERVERURL="$2"; shift ;;
+        --octopus-api-key) OCTOPUSAPIKEY="$2"; shift ;;
+        --octopus-project-name) OCTOPUSPROJECTNAME="$2"; shift ;;
         -d|--dryrun) DRYRUN="-dryrun" ;;
         --version) SHOW_VERSION=true ;;
         --) shift; SCRIPT_ARGUMENTS+=("$@"); break ;;
@@ -101,5 +107,5 @@ fi
 if $SHOW_VERSION; then
     exec mono "$CAKE_EXE" -version
 else
-    exec mono "$CAKE_EXE" $SCRIPT -verbosity=$VERBOSITY -configuration=$CONFIGURATION -target=$TARGET -image-directory=$IMAGEDIRECTORY -docker-namespace=$DOCKERNAMESPACE $DRYRUN "${SCRIPT_ARGUMENTS[@]}"
+    exec mono "$CAKE_EXE" $SCRIPT -verbosity=$VERBOSITY -configuration=$CONFIGURATION -target=$TARGET -image-directory=$IMAGEDIRECTORY -docker-namespace=$DOCKERNAMESPACE -octopus-server-url=$OCTOPUSSERVERURL -octopus-api-key=$OCTOPUSAPIKEY -octopus-project-name=$OCTOPUSPROJECTNAME $DRYRUN "${SCRIPT_ARGUMENTS[@]}"
 fi


### PR DESCRIPTION
Changes to create a release in octopus after pushing images to artifactory. Currently this is pointing to a pre-prod instance and a staging artifactory instance for testing.