### PR TITLE
Enable Production releases (Windows)

### DIFF
--- a/.octopus/windows.ltsc2019/deployment_process.ocl
+++ b/.octopus/windows.ltsc2019/deployment_process.ocl
@@ -1,7 +1,7 @@
 step "Push Docker image" {
 
     action {
-        environments = ["Staging"]
+        environments = ["Staging", "Production"]
         properties = {
             DockerPush.Target.Docker.Registry.Hostname = "#{Docker.Registry.Target.Hostname}"
             DockerPush.Target.Docker.Registry.Password = "#{Docker.Registry.Target.Password}"


### PR DESCRIPTION
This enables the release to dockerhub of Worker Tools images from artifactory. Currently, this points to a private repository for testing purposes and will be updated after testing