### PR TITLE
[WIP] Enthusiastic Promotor for Worker Tool images

### DIFF
--- a/EnthusiasticPromotions/enthusiastic-promotor.ps1
+++ b/EnthusiasticPromotions/enthusiastic-promotor.ps1
@@ -10,10 +10,10 @@ param (
     [Parameter()][string] $dynamicWorkerProdEnvironment = "Environments-842",
 
     [Parameter()][string] $targetInstanceApiKey = "",
-    [Parameter()][string] $targetInstanceUrl        = "https://deploy-fnm.testoctopus.app",
+    [Parameter()][string] $targetInstanceUrl        = "https://deploy.octopus.app",
     [Parameter()][string] $targetProjectId          = "Projects-381",
-    [Parameter()][string] $targetSpaceId            = "Spaces-1",
-    [Parameter()][string] $runbookProjectId         = "Projects-386",
+    [Parameter()][string] $targetSpaceId            = "Projects-6481",
+    [Parameter()][string] $runbookProjectId         = "",
 
     [Parameter()][string] $targetProjectTestEnvironment = "Environments-61",
     [Parameter()][string] $targetProjectProdEnvironment = "Environments-62"

--- a/EnthusiasticPromotions/enthusiastic-promotor.ps1
+++ b/EnthusiasticPromotions/enthusiastic-promotor.ps1
@@ -62,12 +62,12 @@ function Get-PromotionCandidates([Release[]]$dynamicWorkerReleases, [Deployment[
 
     $candidateReleases = @()
     foreach ($release in $chronologicalReleases) {
-        $deployedToEnvironments = $dynamicWorkerDeployments | Where-Object { $_.ReleaseId -eq $release.Release.ReleaseID } | Select-Object -ExpandProperty EnvironmentId
+        $deployedToEnvironments = $dynamicWorkerDeployments | Where-Object { $_.ReleaseId -eq $release.Release.ReleaseId } | Select-Object -ExpandProperty EnvironmentId
 
         if ($deployedToEnvironments -contains $testEnvironment) {
             if ($deployedToEnvironments -contains $prodEnvironment) {
                 foreach ($supersededCandidate in $candidateReleases) {
-                    Write-Host "Ignoring $($supersededCandidate.ReleaseID) because it is superseded by $($release.ReleaseId), which was created later and has been fully promoted."
+                    Write-Verbose "Ignoring $($supersededCandidate.ReleaseId) because it is superseded by $($release.Release.ReleaseId), which was created later and has been fully promoted."
                 }
 
                 $candidateReleases = @()

--- a/EnthusiasticPromotions/enthusiastic-promotor.ps1
+++ b/EnthusiasticPromotions/enthusiastic-promotor.ps1
@@ -47,7 +47,7 @@ function Get-FromApi($url, $apiKey) {
     return $result
 }
 
-function Get-PromotionCandidates([Release[]]$workerToolReleases, [Deployment[]]$workerToolDeployments, [string]$testEnvironment, [string]$prodEnvironment) {
+function Select-PromotionCandidates([Release[]]$workerToolReleases, [Deployment[]]$workerToolDeployments, [string]$testEnvironment, [string]$prodEnvironment) {
     if ($workerToolReleases.Count -eq 0 -or $workerToolDeployments.Count -eq 0) {
         return
     }

--- a/EnthusiasticPromotions/enthusiastic-promotor.ps1
+++ b/EnthusiasticPromotions/enthusiastic-promotor.ps1
@@ -40,9 +40,16 @@ function Get-PromotionCandidates([Release[]]$dynamicWorkerReleases, [Deployment[
     }
 
     $deploymentsByRelease = $dynamicWorkerDeployments | Group-Object -Property "ReleaseId"
-    $candidateReleases = $deploymentsByRelease | Where-Object { ($_.Group | Select-Object -Property EnvironmentId) -contains $targetProjectTestEnvironment -and -not ($_.Group | Select-Object -Property EnvironmentId) -contains $targetProjectProdEnvironment }
+    
+    $candidateReleases = @()
+    foreach ($release in $deploymentsByRelease) {
+        $deployedToEnvironments = $release.Group | Select-Object -ExpandProperty EnvironmentId
+        if ($deployedToEnvironments -contains $targetProjectTestEnvironment -and -not ($deployedToEnvironments -contains $targetProjectProdEnvironment)) {
+            $candidateReleases += $release.Name
+        }
+    }
 
-    $candidateReleases
+    $dynamicWorkerReleases | Where-Object { $candidateReleases -contains $_.ReleaseId }
 }
 
 function Get-ProductionDWVersions {

--- a/EnthusiasticPromotions/enthusiastic-promotor.ps1
+++ b/EnthusiasticPromotions/enthusiastic-promotor.ps1
@@ -47,22 +47,22 @@ function Get-FromApi($url, $apiKey) {
     return $result
 }
 
-function Get-PromotionCandidates([Release[]]$dynamicWorkerReleases, [Deployment[]]$dynamicWorkerDeployments, [string]$testEnvironment, [string]$prodEnvironment) {
-    if ($dynamicWorkerReleases.Count -eq 0 -or $dynamicWorkerDeployments.Count -eq 0) {
+function Get-PromotionCandidates([Release[]]$workerToolReleases, [Deployment[]]$workerToolDeployments, [string]$testEnvironment, [string]$prodEnvironment) {
+    if ($workerToolReleases.Count -eq 0 -or $workerToolDeployments.Count -eq 0) {
         return
     }
 
-    $chronologicalReleases = $dynamicWorkerReleases | `
+    $chronologicalReleases = $workerToolReleases | `
         Sort-Object -Property "Created", "ReleaseId" -PipelineVariable Release | `
         Foreach-Object { @{ 
             Release = $Release; 
-            Deployments = ($dynamicWorkerDeployments | Where-Object { $_.ReleaseId -eq $Release.ReleaseId }) 
+            Deployments = ($workerToolDeployments | Where-Object { $_.ReleaseId -eq $Release.ReleaseId }) 
         } 
     }
 
     $candidateReleases = @()
     foreach ($release in $chronologicalReleases) {
-        $deployedToEnvironments = $dynamicWorkerDeployments | Where-Object { $_.ReleaseId -eq $release.Release.ReleaseId } | Select-Object -ExpandProperty EnvironmentId
+        $deployedToEnvironments = $workerToolDeployments | Where-Object { $_.ReleaseId -eq $release.Release.ReleaseId } | Select-Object -ExpandProperty EnvironmentId
 
         if ($deployedToEnvironments -contains $testEnvironment) {
             if ($deployedToEnvironments -contains $prodEnvironment) {

--- a/EnthusiasticPromotions/enthusiastic-promotor.ps1
+++ b/EnthusiasticPromotions/enthusiastic-promotor.ps1
@@ -80,7 +80,7 @@ function Select-PromotionCandidates([Release[]]$workerToolReleases, [Deployment[
     $candidateReleases
 }
 
-function Get-ProductionDWVersions {
+function Select-ProductionDynamicWorkerRelease([Release[]]$dynamicWorkerReleases, [Deployment[]]$dynamicWorkerDeployments) {
     $releases = @();
 
     foreach ($tenant in $dynamicWorkerProductionTenants) {
@@ -107,5 +107,15 @@ function Invoke-Promotions() {
     # Find our candidates for promotion
     $workerToolsReleases        = Get-Release $workerToolsProject
     $workerToolsDeployments     = Get-Deployment $workerToolsProject
-    $promotionCandidates        = Get-PromotionCandidates $workerToolsReleases $workerToolsDeployments $targetProjectTestEnvironment $targetProjectProdEnvironment
+    $promotionCandidates        = Select-PromotionCandidates $workerToolsReleases $workerToolsDeployments $targetProjectTestEnvironment $targetProjectProdEnvironment
+
+    # Find the current Dynamic Worker production version
+    $dynamicWorkerReleases      = Get-Release $dynamicWorkerProject
+    $dynamicWorkerDeployments   = Get-Deployment $dynamicWorkerProject
+    $currentProductionDw        = Select-ProductionDynamicWorkerRelease $dynamicWorkerReleases $dynamicWorkerDeployments
+
+    # Figure out cached versions of current prod release from TC parameter
+
+    # Promote whichever candidates are ready
+
 }

--- a/EnthusiasticPromotions/enthusiastic-promotor.ps1
+++ b/EnthusiasticPromotions/enthusiastic-promotor.ps1
@@ -19,7 +19,7 @@ param (
     [Parameter()][string] $targetProjectProdEnvironment = "Environments-62"
 )
 
-$productionTenants = @("Tenants-8286", "Tenants-8287", "Tenants-8288")
+$dynamicWorkerProductionTenants = @("Tenants-8286", "Tenants-8287", "Tenants-8288")
 
 function Get-FromApi($url, $apiKey) {
     Write-Verbose "Getting response from $url"
@@ -70,7 +70,7 @@ function Get-PromotionCandidates([Release[]]$dynamicWorkerReleases, [Deployment[
 function Get-ProductionDWVersions {
     $releases = @();
 
-    foreach ($tenant in $productionTenants) {
+    foreach ($tenant in $dynamicWorkerProductionTenants) {
         $releasesInProductionResponse = Get-FromApi "$dynamicWorkerInstanceUrl/api/$dynamicWorkerSpaceId/deployments?projects=$dynamicWorkerProjectId&environments=$dynamicWorkerProdEnvironment&tenants=$tenant" $dynamicWorkerInstanceApiKey
         $release = $releasesInProductionResponse.Items | Sort-Object -Property "Created" -Descending | Select-Object -First 1
         

--- a/EnthusiasticPromotions/enthusiastic-promotor.ps1
+++ b/EnthusiasticPromotions/enthusiastic-promotor.ps1
@@ -1,24 +1,292 @@
-using module .\enthusiastic-promotor.psm1
-
 [CmdletBinding()]
 param (
-    [Parameter()][string] $dynamicWorkerInstanceApiKey = "",
-    [Parameter()][string] $dynamicWorkerInstanceUrl = "https://deploy.octopus.app",
-    [Parameter()][string] $dynamicWorkerProjectId   = "Projects-5063",
-    [Parameter()][string] $dynamicWorkerSpaceId     = "Spaces-142",
+    [Parameter()][string] $dynamicWorkerInstanceApiKey,
+    [Parameter()][string] $dynamicWorkerInstanceUrl,
+    [Parameter()][string] $dynamicWorkerSpaceId,
+    [Parameter()][string] $dynamicWorkerProjectId,
+    [Parameter()][string] $dynamicWorkerProdEnvironmentId,
 
-    [Parameter()][string] $dynamicWorkerProdEnvironment = "Environments-842",
+    [Parameter()][string] $targetInstanceApiKey,
+    [Parameter()][string] $targetInstanceUrl,
+    [Parameter()][string] $targetSpaceId,  
+    [Parameter()][string] $targetProjectId,
+    [Parameter()][string] $targetProjectStagingEnvironmentId,
+    [Parameter()][string] $targetProjectProdEnvironmentId,
 
-    [Parameter()][string] $targetInstanceApiKey = "",
-    [Parameter()][string] $targetInstanceUrl        = "https://deploy.octopus.app",
-    [Parameter()][string] $targetProjectId          = "Projects-381",
-    [Parameter()][string] $targetSpaceId            = "Projects-6481",
-    [Parameter()][string] $runbookProjectId         = "",
+    [Parameter()][string] $teamCityToken,
+    [Parameter()][string] $teamCityUrl,
+    [Parameter()][string] $teamCityProjectName,
 
-    [Parameter()][string] $targetProjectTestEnvironment = "Environments-61",
-    [Parameter()][string] $targetProjectProdEnvironment = "Environments-62"
+    [Parameter()][string] $osSuffix,
+    [Parameter()][switch] $dryRun = $false
 )
 
+$dynamicWorkerProductionTenantIds = @(
+    "Tenants-8286"
+    "Tenants-8287"
+    "Tenants-8288"
+)
+
+function Get-FromApi($url, $headers, $formatter) {
+    Write-Verbose "Getting response from $url"
+    $result = Invoke-RestMethod -Uri "$url" -Headers $headers -TimeoutSec 60 -RetryIntervalSec 10 -MaximumRetryCount 2
+    Write-Debug "--------------------------------------------------------"
+    Write-Debug "response:"
+    Write-Debug "--------------------------------------------------------"
+    Write-Debug $($formatter.Invoke($result))
+    Write-Debug "--------------------------------------------------------"
+    return $result
+}
+
+function Get-FromOctopusApi($url, $apiKey) {
+    Get-FromApi $url @{ "X-Octopus-ApiKey" = $apiKey } { Param($result) $result | ConvertTo-Json -depth 10 }
+}
+
+function Get-FromTeamCityApi($url, $token) {
+    Get-FromApi $url @{ "Authorization" = "Bearer $teamCityToken" } { Param($result) $result.outerXml }
+}
+
+function Get-Releases($octopusProject) {
+    $releasesResponse = Get-FromOctopusApi "$($octopusProject.BaseUri)/api/$($octopusProject.SpaceId)/projects/$($octopusProject.ProjectId)/releases" $octopusProject.ApiKey
+    $releasesResponse.Items | Foreach-Object {
+        @{
+            ReleaseId = $_.Id
+            ProjectId = $_.ProjectId
+            Version = $_.Version
+            Created = $_.Assembled
+        }
+    }
+}
+
+function Get-Deployments($octopusProject) {
+    $deploymentsResponse = Get-FromOctopusApi "$($octopusProject.BaseUri)/api/$($octopusProject.SpaceId)/deployments?projects=$($octopusProject.ProjectId)" $octopusProject.ApiKey
+    $deploymentsResponse.Items | Foreach-Object {
+        @{
+            DeploymentId = $_.Id
+            ReleaseId = $_.ReleaseId
+            EnvironmentId = $_.EnvironmentId
+            TaskId = $_.TaskId
+        }
+    }
+}
+
+function Get-ReleaseVersion($octopusProject, $releaseId) {
+    $releaseDetailsResponse = Get-FromOctopusApi "$($octopusProject.BaseUri)/api/$($octopusProject.SpaceId)/releases/$releaseId" $octopusProject.ApiKey
+    $releaseDetailsResponse.Version
+}
+
+function Test-DeploymentSuccessful($octopusProject, $deployment) {
+    $taskResponse = Get-FromOctopusApi "$($octopusProject.BaseUri)/api/$($octopusProject.SpaceId)/tasks/$($deployment.TaskId)" $octopusProject.ApiKey
+    $taskResponse.FinishedSuccessfully
+}
+
+function Get-ProductionDynamicWorkerReleaseIds($dynamicWorkerProductionTenantIds) {
+    $deployments = @();
+    foreach ($tenantId in $dynamicWorkerProductionTenantIds) {
+        $productionDynamicWorkerDeploymentsResponse = Get-FromOctopusApi "$dynamicWorkerInstanceUrl/api/$dynamicWorkerSpaceId/deployments?projects=$dynamicWorkerProjectId&environments=$dynamicWorkerProdEnvironmentId&tenants=$tenantId" $dynamicWorkerInstanceApiKey
+        $deployment = $productionDynamicWorkerDeploymentsResponse.Items | Sort-Object -Property "Created" -Descending | Select-Object -First 1
+        $deployments += $deployment
+    }
+    $deployments | Select-Object -ExpandProperty ReleaseId -Unique
+}
+
+function Get-DynamicWorkerBuildId($releaseId) {
+    $buildNumber = Get-ReleaseVersion $dynamicWorkerProject $releaseId
+    $buildInformationResponse = Get-FromTeamCityApi "$teamCityUrl/app/rest/builds?locator=buildType:$teamCityProjectName,number:$buildNumber"
+    $buildInformationResponse | Select-Xml -XPath "/builds/build" | ForEach-Object { $_.Node.id } | Select-Object -First 1
+}
+
+function Get-CachedWorkerToolsVersions($releaseId) {
+    $buildId = Get-DynamicWorkerBuildId $releaseId
+    $buildParametersResponse = Get-FromTeamCityApi "$teamCityUrl/app/rest/builds/$buildId/resulting-properties"
+    $cachedWorkerToolsVersionsValue = $buildParametersResponse `
+        | Select-Xml -XPath "/properties/property" `
+        | Where-Object { $_.Node.name -eq "CachedWorkerToolsVersions" } `
+        | Select-Object -First 1 -ExpandProperty value
+    $cachedWorkerToolsVersions = $cachedWorkerToolsVersionsValue -split "," | Select-Object -Unique
+    Write-Verbose "Cached worker tools versions for Dynamic Worker release $($releaseId):"
+    $cachedWorkerToolsVersions | ForEach-Object { Write-Verbose " - $_" }
+    $cachedWorkerToolsVersions
+}
+
+function Select-PromotionCandidates($workerToolReleases, $workerToolDeployments, $stagingEnvironmentId, $prodEnvironmentId) {
+    if ($workerToolReleases.Count -eq 0 -or $workerToolDeployments.Count -eq 0) {
+        return @()
+    }
+
+    $chronologicalReleases = $workerToolReleases `
+        | Sort-Object -Property "Created", "ReleaseId" -PipelineVariable Release `
+        | Foreach-Object { 
+            @{ 
+                Release = $Release; 
+                Deployments = ($workerToolDeployments | Where-Object { $_.ReleaseId -eq $Release.ReleaseId }) 
+            } 
+        }
+
+    $candidateReleases = @()
+    foreach ($release in $chronologicalReleases) {
+        $deployedToEnvironments = $workerToolDeployments | Where-Object { $_.ReleaseId -eq $release.Release.ReleaseId } | Select-Object -ExpandProperty EnvironmentId
+        if ($deployedToEnvironments -contains $stagingEnvironmentId) {
+            if ($deployedToEnvironments -contains $prodEnvironmentId) {
+                foreach ($supersededCandidate in $candidateReleases) {
+                    Write-Verbose "Ignoring $($supersededCandidate.Version) because it is superseded by $($release.Release.Version), which was created later and has been fully promoted."
+                }
+
+                $candidateReleases = @()
+            } else {
+                $candidateReleases += $release.Release
+            }
+        } else {
+            Write-Verbose "Ignoring $($release.Release.Version) because it has not been successfully deployed to Staging"
+        }
+    }
+
+    $candidateReleases
+}
+
+function Select-CommonCachedVersions($cachedVersionLists) {
+    if ($cachedVersionLists.Count -eq 0) {
+        return @()
+    }
+
+    $cachedVersions = $cachedVersionLists[0];
+    foreach ($versionList in $cachedVersionLists) {
+        $cachedVersions = $versionList | Where-Object { $cachedVersions -contains $_ }
+    }
+
+    $cachedVersions | Select-Object -Unique
+}
+
+function Select-CachedCandidates($promotionCandidates, $cachedWorkerToolsVersions, $osSuffix) {
+    $promotionCandidates | Where-Object { "$($_.version)-$osSuffix" -in $cachedWorkerToolsVersions }
+}
+
+function New-Promotion($release) {
+    & octo deploy-release `
+        --deployTo $targetProjectProdEnvironmentId `
+        --version $release.Version `
+        --project $targetProjectId `
+        --apiKey $targetInstanceApiKey `
+        --server "$targetInstanceUrl" `
+        --space $targetSpaceId
+}
+
+function Invoke-Promotion() {
+    Write-Host "Finding promotion candidates..."
+
+    $workerToolsReleases = Get-Releases $workerToolsProject
+    $workerToolsDeployments = Get-Deployments $octopusProject | Where-Object { Test-DeploymentSuccessful $octopusProject $_ }
+    $promotionCandidates = Select-PromotionCandidates $workerToolsReleases $workerToolsDeployments $targetProjectStagingEnvironmentId $targetProjectProdEnvironmentId
+
+    if ($promotionCandidates.Count -eq 0) {
+        Write-Host "No candidates are waiting for promotion"
+        exit 0
+    }
+
+    Write-Host "Candidates for promotion:"
+    $promotionCandidates | ForEach-Object { Write-Host " - $($_.Version)" }
+
+    Write-Host "Finding cached Worker Tools versions in production..."
+
+    $cachedWorkerToolsVersionLists =  Get-ProductionDynamicWorkerReleaseIds $dynamicWorkerProject.ProductionTenants `
+        | ForEach-Object { , (Get-CachedWorkerToolsVersions $_) } 
+    $commonCachedWorkerToolsVersions = Select-CommonCachedVersions $cachedWorkerToolsVersionLists
+
+    if ($commonCachedWorkerToolsVersions.Count -eq 0) {
+        Write-Warning "Cannot find Worker Tools version cached in production"
+        exit 1
+    }
+
+    Write-Host "Cached Worker Tools versions in production:"
+    $commonCachedWorkerToolsVersions | ForEach-Object { Write-Host " - $_" }
+
+    Write-Host "Deciding Worker Tools releases to promote..."
+
+    $cachedCandidates = Select-CachedCandidates $promotionCandidates $commonCachedWorkerToolsVersions $osSuffix
+
+    if ($cachedCandidates.Count -eq 0) {
+        Write-Host "No candidates are cached in production"
+        exit 0
+    }
+
+    Write-Host "Worker Tools releases to promote are:"
+    $cachedCandidates | ForEach-Object { Write-Host " - $($_.Version)" }
+
+    foreach ($release in $cachedCandidates) {
+        if ($dryRun) {
+            Write-Host "Skip promoting version $($release.Version) since this is a dry run"
+        } else {
+            New-Promotion $release
+            Write-Host "Promoted release $($release.Version)"
+        }
+    }
+}
+
+function Test-AnyArgsPassed {
+    return $dynamicWorkerInstanceApiKey `
+    -or $dynamicWorkerInstanceUrl `
+    -or $dynamicWorkerSpaceId `
+    -or $dynamicWorkerProjectId `
+    -or $dynamicWorkerProdEnvironmentId `
+    -or $targetInstanceApiKey `
+    -or $targetInstanceUrl `
+    -or $targetSpaceId `
+    -or $targetProjectId `
+    -or $targetProjectStagingEnvironmentId `
+    -or $targetProjectProdEnvironmentId `
+    -or $teamCityToken `
+    -or $teamCityUrl `
+    -or $teamCityProjectName `
+    -or $osSuffix
+}
+
+function Test-AllArgsPassed {
+    return $dynamicWorkerInstanceApiKey `
+    -and $dynamicWorkerInstanceUrl `
+    -and $dynamicWorkerSpaceId `
+    -and $dynamicWorkerProjectId `
+    -and $dynamicWorkerProdEnvironmentId `
+    -and $targetInstanceApiKey `
+    -and $targetInstanceUrl `
+    -and $targetSpaceId `
+    -and $targetProjectId `
+    -and $targetProjectStagingEnvironmentId `
+    -and $targetProjectProdEnvironmentId `
+    -and $teamCityToken `
+    -and $teamCityUrl `
+    -and $teamCityProjectName `
+    -and $osSuffix
+}
+
+
+if (Test-Path variable:OctopusParameters) {
+    Write-Host "Reading parameters from `$OctopusParameters"
+
+    $dynamicWorkerInstanceApiKey       = $OctopusParameters["DynamicWorkerInstanceApiKey"]
+    $dynamicWorkerInstanceUrl          = $OctopusParameters["DynamicWorkerInstanceUrl"]
+    $dynamicWorkerSpaceId              = $OctopusParameters["DynamicWorkerSpaceId"]
+    $dynamicWorkerProjectId            = $OctopusParameters["DynamicWorkerProjectId"]
+    $dynamicWorkerProdEnvironmentId    = $OctopusParameters["DynamicWorkerProdEnvironmentId"]
+
+    $targetInstanceApiKey              = $OctopusParameters["TargetInstanceApiKey"]
+    $targetInstanceUrl                 = $OctopusParameters["Octopus.Web.ServerUri"]
+    $targetSpaceId                     = $OctopusParameters["Octopus.Space.Id"]
+    $targetProjectId                   = $OctopusParameters["Octopus.Project.Id"]
+    $targetProjectStagingEnvironmentId = $OctopusParameters["TargetInstanceStagingEnvironmentId"]
+    $targetProjectProdEnvironmentId    = $OctopusParameters["TargetInstanceProdEnvironmentId"]
+
+    $teamCityToken                     = $OctopusParameters["TeamCityToken"]
+    $teamCityUrl                       = $OctopusParameters["TeamCityUrl"]
+    $teamCityProjectName               = $OctopusParameters["TeamCityProjectName"]
+
+    $osSuffix                          = $OctopusParameters["OsSuffix"]
+} elseif (Test-AllArgsPassed) {
+    Write-Host "Reading parameters from command line args"
+} elseif (Test-AnyArgsPassed) {
+    Write-Warning "Some command line args have been passed, but some are missing. Please validated the args you are passing!"
+    exit 1
+}
+  
 $workerToolsProject = @{ 
     BaseUri = $targetInstanceUrl
     ApiKey = $targetInstanceApiKey
@@ -31,91 +299,36 @@ $dynamicWorkerProject = @{
     ApiKey = $dynamicWorkerInstanceApiKey
     ProjectId = $dynamicWorkerProjectId
     SpaceId = $dynamicWorkerSpaceId 
-    ProductionTenants = @("Tenants-8286", "Tenants-8287", "Tenants-8288")
+    ProductionTenants = $dynamicWorkerProductionTenantIds
 }
 
-function Get-FromApi($url, $apiKey) {
-    Write-Verbose "Getting response from $url"
-    $result = Invoke-RestMethod -Uri $url -Headers @{ 'X-Octopus-ApiKey' = $apiKey } -TimeoutSec 60 -RetryIntervalSec 10 -MaximumRetryCount 2
+if (Test-AllArgsPassed) {
+    Write-Debug "Running with parameters: "
+    Write-Debug "  dynamicWorkerInstanceUrl: $dynamicWorkerInstanceUrl"
+    Write-Debug "  dynamicWorkerSpaceId: $dynamicWorkerSpaceId"
+    Write-Debug "  dynamicWorkerProjectId: $dynamicWorkerProjectId"
+    Write-Debug "  dynamicWorkerProdEnvironmentId: $dynamicWorkerProdEnvironmentId"
 
-    # log out the  json, so we can diagnose what's happening / write a test for it
-    Write-Debug "--------------------------------------------------------"
-    Write-Debug "response:"
-    Write-Debug "--------------------------------------------------------"
-    Write-Debug ($result | ConvertTo-Json -depth 10)
-    Write-Debug "--------------------------------------------------------"
-    return $result
-}
+    Write-Debug "  targetInstanceUrl: $targetInstanceUrl"
+    Write-Debug "  targetSpaceId: $targetSpaceId"
+    Write-Debug "  targetProjectId: $targetProjectId"
+    Write-Debug "  targetProjectStagingEnvironmentId: $targetProjectStagingEnvironmentId"
+    Write-Debug "  targetProjectProdEnvironmentId: $targetProjectProdEnvironmentId"
 
-function Select-PromotionCandidates([Release[]]$workerToolReleases, [Deployment[]]$workerToolDeployments, [string]$testEnvironment, [string]$prodEnvironment) {
-    if ($workerToolReleases.Count -eq 0 -or $workerToolDeployments.Count -eq 0) {
-        return
-    }
+    Write-Debug "  teamCityUrl: $teamCityUrl"
+    Write-Debug "  teamCityProjectName: $teamCityProjectName"
 
-    $chronologicalReleases = $workerToolReleases | `
-        Sort-Object -Property "Created", "ReleaseId" -PipelineVariable Release | `
-        Foreach-Object { @{ 
-            Release = $Release; 
-            Deployments = ($workerToolDeployments | Where-Object { $_.ReleaseId -eq $Release.ReleaseId }) 
-        } 
-    }
+    Write-Debug "  osSuffix: $osSuffix"
 
-    $candidateReleases = @()
-    foreach ($release in $chronologicalReleases) {
-        $deployedToEnvironments = $workerToolDeployments | Where-Object { $_.ReleaseId -eq $release.Release.ReleaseId } | Select-Object -ExpandProperty EnvironmentId
-
-        if ($deployedToEnvironments -contains $testEnvironment) {
-            if ($deployedToEnvironments -contains $prodEnvironment) {
-                foreach ($supersededCandidate in $candidateReleases) {
-                    Write-Verbose "Ignoring $($supersededCandidate.ReleaseId) because it is superseded by $($release.Release.ReleaseId), which was created later and has been fully promoted."
-                }
-
-                $candidateReleases = @()
-            } else {
-                $candidateReleases += $release.Release
-            }
+    try {
+        Invoke-Promotion
+    } catch {
+        [System.Console]::Error.WriteLine("$($error[0].CategoryInfo.Category): $($error[0].Exception.Message)")
+        [System.Console]::Error.WriteLine($error[0].InvocationInfo.PositionMessage)
+        [System.Console]::Error.WriteLine($error[0].ScriptStackTrace)
+        if ($null -ne $error[0].ErrorDetails) {
+            [System.Console]::Error.WriteLine($error[0].ErrorDetails.Message)
         }
+        exit 1
     }
-
-    $candidateReleases
-}
-
-function Select-ProductionDynamicWorkerRelease([Release[]]$dynamicWorkerReleases, [Deployment[]]$dynamicWorkerDeployments) {
-    $releases = @();
-
-    foreach ($tenant in $dynamicWorkerProductionTenants) {
-        $releasesInProductionResponse = Get-FromApi "$dynamicWorkerInstanceUrl/api/$dynamicWorkerSpaceId/deployments?projects=$dynamicWorkerProjectId&environments=$dynamicWorkerProdEnvironment&tenants=$tenant" $dynamicWorkerInstanceApiKey
-        $release = $releasesInProductionResponse.Items | Sort-Object -Property "Created" -Descending | Select-Object -First 1
-        
-        $releases += $release
-    }
-
-    Write-Host ($releases | Select-Object -ExpandProperty "ReleaseId")
-}
-
-function Get-Release($octopusProject) {
-    $releasesResponse = Get-FromApi "$($octopusProject.BaseUri)/api/projects/$($octopusProject.ProjectId)/releases" $octopusProject.ApiKey
-    $releasesResponse.Items | Foreach-Object { [Release]::new($_.Id, $_.ProjectId, $_.Assembled) }
-}
-
-function Get-Deployment($octopusProject) {
-    $deploymentsResponse = Get-FromApi "$($octopusProject.BaseUri)/api/deployments?projects=$($octopusProject.ProjectId)" $octopusProject.ApiKey
-    $deploymentsResponse.Items | Foreach-Object { [Deployment]::new($_.Id, $_.ReleaseId, $_.EnvironmentId) }
-}
-
-function Invoke-Promotions() {
-    # Find our candidates for promotion
-    $workerToolsReleases        = Get-Release $workerToolsProject
-    $workerToolsDeployments     = Get-Deployment $workerToolsProject
-    $promotionCandidates        = Select-PromotionCandidates $workerToolsReleases $workerToolsDeployments $targetProjectTestEnvironment $targetProjectProdEnvironment
-
-    # Find the current Dynamic Worker production version
-    $dynamicWorkerReleases      = Get-Release $dynamicWorkerProject
-    $dynamicWorkerDeployments   = Get-Deployment $dynamicWorkerProject
-    $currentProductionDw        = Select-ProductionDynamicWorkerRelease $dynamicWorkerReleases $dynamicWorkerDeployments
-
-    # Figure out cached versions of current prod release from TC parameter
-
-    # Promote whichever candidates are ready
-
 }

--- a/EnthusiasticPromotions/enthusiastic-promotor.ps1
+++ b/EnthusiasticPromotions/enthusiastic-promotor.ps1
@@ -1,3 +1,5 @@
+[CmdletBinding()]
+param ()
 
 $promotionProjectId = "Projects-386"
 $dockerhubEnvironmentId = "Environments-62"

--- a/EnthusiasticPromotions/enthusiastic-promotor.ps1
+++ b/EnthusiasticPromotions/enthusiastic-promotor.ps1
@@ -1,0 +1,45 @@
+
+$promotionProjectId = "Projects-386"
+$dockerhubEnvironmentId = "Environments-62"
+
+$hostedSpace = "Spaces-142"
+$dwProjectId = "Projects-5063"
+$productionEnvironmentId = "Environments-842"
+$productionTenants = @("Tenants-8286", "Tenants-8287", "Tenants-8288")
+
+$branchUrl = "https://deploy-fnm.testoctopus.app"
+$branchApiKey = "API-Key"
+
+$deployUrl = "https://deploy.octopus.app"
+$deployApiKey = "API-Key"
+
+function Get-PromotionCandidates {
+    $promotedDeploymentsResponse = (Invoke-WebRequest -Uri "$branchUrl/api/deployments?projects=$promotionProjectId&environments=$dockerhubEnvironmentId" -Headers @{ "X-Octopus-ApiKey"=$branchApiKey }).Content | ConvertFrom-Json
+    $promotedReleases = $promotedDeploymentsResponse.Items | Select-Object -ExpandProperty "ReleaseId" -Unique
+
+    $allReleasesResponse = (Invoke-WebRequest -Uri "$branchUrl/api/deployments?projects=$promotionProjectId" -Headers @{ "X-Octopus-ApiKey"=$branchApiKey }).Content | ConvertFrom-Json
+    $allReleases = $allReleasesResponse.Items | Select-Object -ExpandProperty "ReleaseId" -Unique
+
+    $candidates = $allReleases | Where-Object { -not ($_ -in $promotedReleases) } 
+
+    Write-Host $candidates
+}
+
+function Get-ProductionDWVersions {
+    $releases = @();
+
+    foreach ($tenant in $productionTenants) {
+        $releasesInProductionResponse = (Invoke-WebRequest -Uri "$deployUrl/api/$hostedSpace/deployments?projects=$dwProjectId&environments=$productionEnvironmentId&tenants=$tenant" -Headers @{ "X-Octopus-ApiKey"=$deployApiKey }).Content | ConvertFrom-Json
+        $release = $releasesInProductionResponse.Items | Sort-Object -Property "Created" -Descending | Select-Object -First 1
+        
+        $releases += $release
+    }
+
+    Write-Host ($releases | Select-Object -ExpandProperty "ReleaseId")
+}
+
+function Get-CachedImageVersions() {
+    
+}
+
+Get-ProductionDWVersions

--- a/EnthusiasticPromotions/enthusiastic-promotor.ps1
+++ b/EnthusiasticPromotions/enthusiastic-promotor.ps1
@@ -39,12 +39,10 @@ function Get-PromotionCandidates([Release[]]$dynamicWorkerReleases, [Deployment[
         return
     }
 
-    $uniqueReleases = $dynamicWorkerReleases | Select-Object Property "ReleaseId" -Unique
-    $promotedReleases = $dynamicWorkerDeployments | Select-Object -Property "ReleaseId" -Unique
+    $deploymentsByRelease = $dynamicWorkerDeployments | Group-Object -Property "ReleaseId"
+    $candidateReleases = $deploymentsByRelease | Where-Object { ($_.Group | Select-Object -Property EnvironmentId) -contains $targetProjectTestEnvironment -and -not ($_.Group | Select-Object -Property EnvironmentId) -contains $targetProjectProdEnvironment }
 
-    $candidates = $uniqueReleases | Where-Object { -not ($_ -in $promotedReleases) } 
-
-    Write-Host $candidates
+    $candidateReleases
 }
 
 function Get-ProductionDWVersions {

--- a/EnthusiasticPromotions/enthusiastic-promotor.ps1
+++ b/EnthusiasticPromotions/enthusiastic-promotor.ps1
@@ -1,3 +1,5 @@
+using module .\enthusiastic-promotor.psm1
+
 [CmdletBinding()]
 param (
     [Parameter()][string] $dynamicWorkerInstanceApiKey = "",
@@ -9,38 +11,15 @@ param (
     [Parameter()][string] $targetInstanceUrl        = "https://deploy-fnm.testoctopus.app",
     [Parameter()][string] $targetProjectId          = "Projects-381",
     [Parameter()][string] $targetSpaceId            = "Spaces-1",
-    [Parameter()][string] $runbookProjectId         = "Projects-386"
+    [Parameter()][string] $runbookProjectId         = "Projects-386",
+
+    [Parameter()][string] $targetProjectTestEnvironment = "Environments-61",
+    [Parameter()][string] $targetProjectProdEnvironment = "Environments-62"
 )
 
 $dockerhubEnvironmentId = "Environments-62"
 $productionEnvironmentId = "Environments-842"
 $productionTenants = @("Tenants-8286", "Tenants-8287", "Tenants-8288")
-
-class Release {
-    [string]$ReleaseId
-    [string]$ProjectId
-    
-    Release() {}
-
-    Release($releaseId, $projectId) {
-        $this.ReleaseId = $releaseId
-        $this.ProjectId = $projectId
-    }
-}
-
-class Deployment {
-    [string]$DeploymentId
-    [string]$ReleaseId
-    [string]$EnvironmentId
-
-    Deployment() {}
-
-    Deployment($deploymentId, $releaseId, $environmentId) {
-        $this.DeploymentId = $deploymentId
-        $this.ReleaseId = $releaseId
-        $this.EnvironmentId = $environmentId
-    }
-}
 
 function Get-FromApi($url, $apiKey) {
     Write-Verbose "Getting response from $url"

--- a/EnthusiasticPromotions/enthusiastic-promotor.ps1
+++ b/EnthusiasticPromotions/enthusiastic-promotor.ps1
@@ -39,7 +39,13 @@ function Get-PromotionCandidates([Release[]]$dynamicWorkerReleases, [Deployment[
         return
     }
 
-    $chronologicalReleases = $dynamicWorkerReleases | Sort-Object -Property "Created", "ReleaseId" -PipelineVariable Release | Foreach-Object { @{ Release = $Release; Deployments = ($dynamicWorkerDeployments | Where-Object { $_.ReleaseId -eq $Release.ReleaseId }) } }
+    $chronologicalReleases = $dynamicWorkerReleases | `
+        Sort-Object -Property "Created", "ReleaseId" -PipelineVariable Release | `
+        Foreach-Object { @{ 
+            Release = $Release; 
+            Deployments = ($dynamicWorkerDeployments | Where-Object { $_.ReleaseId -eq $Release.ReleaseId }) 
+        } 
+    }
         
     $candidateReleases = @()
     foreach ($release in $chronologicalReleases) {

--- a/EnthusiasticPromotions/enthusiastic-promotor.ps1
+++ b/EnthusiasticPromotions/enthusiastic-promotor.ps1
@@ -7,6 +7,8 @@ param (
     [Parameter()][string] $dynamicWorkerProjectId   = "Projects-5063",
     [Parameter()][string] $dynamicWorkerSpaceId     = "Spaces-142",
 
+    [Parameter()][string] $dynamicWorkerProdEnvironment = "Environments-842",
+
     [Parameter()][string] $targetInstanceApiKey = "",
     [Parameter()][string] $targetInstanceUrl        = "https://deploy-fnm.testoctopus.app",
     [Parameter()][string] $targetProjectId          = "Projects-381",
@@ -17,8 +19,6 @@ param (
     [Parameter()][string] $targetProjectProdEnvironment = "Environments-62"
 )
 
-$dockerhubEnvironmentId = "Environments-62"
-$productionEnvironmentId = "Environments-842"
 $productionTenants = @("Tenants-8286", "Tenants-8287", "Tenants-8288")
 
 function Get-FromApi($url, $apiKey) {
@@ -65,7 +65,7 @@ function Get-ProductionDWVersions {
     $releases = @();
 
     foreach ($tenant in $productionTenants) {
-        $releasesInProductionResponse = Get-FromApi "$dynamicWorkerInstanceUrl/api/$dynamicWorkerSpaceId/deployments?projects=$dynamicWorkerProjectId&environments=$productionEnvironmentId&tenants=$tenant" $dynamicWorkerInstanceApiKey
+        $releasesInProductionResponse = Get-FromApi "$dynamicWorkerInstanceUrl/api/$dynamicWorkerSpaceId/deployments?projects=$dynamicWorkerProjectId&environments=$dynamicWorkerProdEnvironment&tenants=$tenant" $dynamicWorkerInstanceApiKey
         $release = $releasesInProductionResponse.Items | Sort-Object -Property "Created" -Descending | Select-Object -First 1
         
         $releases += $release
@@ -79,10 +79,10 @@ function Get-Release($projectId, $baseUrl, $apiToken) {
     $releasesResponse.Items | Foreach-Object { [Release]::new($_.Id, $_.ProjectId) }
 }
 
-function Get-Deployment($projectId, $environment, $baseUrl, $apiToken) {
-    $deploymentsResponse = Get-FromApi "$targetInstanceUrl/api/deployments?projects=$targetProjectId&environments=$dockerhubEnvironmentId" $targetInstanceApiKey
+function Get-Deployment($projectId, $baseUrl, $apiToken) {
+    $deploymentsResponse = Get-FromApi "$targetInstanceUrl/api/deployments?projects=$targetProjectId" $targetInstanceApiKey
     $deploymentsResponse.Items | Foreach-Object { [Deployment]::new($_.Id, $_.ReleaseId, $_.EnvironmentId) }
 }
 
 $dynamicWorkerReleases      = Get-Release $targetProjectId $targetInstanceUrl $targetInstanceApiKey
-$dynamicWorkerDeployments   = Get-Deployment $targetProjectId $dockerhubEnvironmentId $targetInstanceUrl $targetInstanceApiKey
+$dynamicWorkerDeployments   = Get-Deployment $targetProjectId $targetInstanceUrl $targetInstanceApiKey

--- a/EnthusiasticPromotions/enthusiastic-promotor.psm1
+++ b/EnthusiasticPromotions/enthusiastic-promotor.psm1
@@ -1,0 +1,21 @@
+class Release {
+    [string]$ReleaseId
+    [string]$ProjectId
+    
+    Release($releaseId, $projectId) {
+        $this.ReleaseId = $releaseId
+        $this.ProjectId = $projectId
+    }
+}
+
+class Deployment {
+    [string]$DeploymentId
+    [string]$ReleaseId
+    [string]$EnvironmentId
+
+    Deployment($deploymentId, $releaseId, $environmentId) {
+        $this.DeploymentId = $deploymentId
+        $this.ReleaseId = $releaseId
+        $this.EnvironmentId = $environmentId
+    }
+}

--- a/EnthusiasticPromotions/enthusiastic-promotor.psm1
+++ b/EnthusiasticPromotions/enthusiastic-promotor.psm1
@@ -1,10 +1,17 @@
 class Release {
     [string]$ReleaseId
     [string]$ProjectId
+    [DateTime]$CreatedDate
     
     Release($releaseId, $projectId) {
         $this.ReleaseId = $releaseId
         $this.ProjectId = $projectId
+    }
+
+    Release($releaseId, $projectId, $createdDate) {
+        $this.ReleaseId = $releaseId
+        $this.ProjectId = $projectId
+        $this.CreatedDate = $createdDate
     }
 }
 

--- a/EnthusiasticPromotions/enthusiastic-promotor.tests.ps1
+++ b/EnthusiasticPromotions/enthusiastic-promotor.tests.ps1
@@ -39,4 +39,19 @@ Describe "Get-PromotionCandidates" {
         # Assert
         $result.Count | Should -Be 0
     }
+
+    It "with one Release deployed to all environments returns nothing" {
+        # Arrange
+        $releases = [Release[]] @( [Release]::new("Release-1", "Project-1") )
+        $deployments = [Deployment[]] @( 
+            [Deployment]::new("Deployment-1", "Release-1", $stagingEnvironment)
+            [Deployment]::new("Deployment-1", "Release-1", $prodEnvironment)
+        )
+
+        # Act
+        $result = Get-PromotionCandidates $releases $deployments
+
+        # Assert
+        $result.Count | Should -Be 0
+    }
 }

--- a/EnthusiasticPromotions/enthusiastic-promotor.tests.ps1
+++ b/EnthusiasticPromotions/enthusiastic-promotor.tests.ps1
@@ -40,7 +40,7 @@ Describe "Get-PromotionCandidates" {
         $result.Count | Should -Be 0
     }
 
-    It "with one Release deployed to all environments returns nothing" {
+    It "ignores already promoted Releases" {
         # Arrange
         $releases = [Release[]] @( [Release]::new("Release-1", "Project-1") )
         $deployments = [Deployment[]] @( 
@@ -53,5 +53,26 @@ Describe "Get-PromotionCandidates" {
 
         # Assert
         $result.Count | Should -Be 0
+    }
+
+    It "includes unpromoted Releases" {
+        # Arrange
+        $releases = [Release[]] @( 
+            [Release]::new("Release-1", "Project-1") 
+            [Release]::new("Release-2", "Project-1") 
+        )
+        $deployments = [Deployment[]] @( 
+            [Deployment]::new("Deployment-1", "Release-1", $stagingEnvironment)
+            [Deployment]::new("Deployment-1", "Release-1", $prodEnvironment)
+
+            [Deployment]::new("Deployment-1", "Release-2", $stagingEnvironment)
+        )
+
+        # Act
+        $result = Get-PromotionCandidates $releases $deployments
+
+        # Assert
+        $result.Count | Should -Be 1
+        $result[0].ReleaseId | Should -Be "Release-2"
     }
 }

--- a/EnthusiasticPromotions/enthusiastic-promotor.tests.ps1
+++ b/EnthusiasticPromotions/enthusiastic-promotor.tests.ps1
@@ -1,0 +1,10 @@
+BeforeAll {
+    . (Join-Path -Path $PSScriptRoot -ChildPath "enthusiastic-promotor.ps1")
+}
+
+Describe "Get-PromotionCandidates" {
+    It "with no parameters returns nothing" {
+        $result = Get-PromotionCandidates
+        $result.Count | Should -Be 0
+    }
+}

--- a/EnthusiasticPromotions/enthusiastic-promotor.tests.ps1
+++ b/EnthusiasticPromotions/enthusiastic-promotor.tests.ps1
@@ -107,3 +107,19 @@ Describe "Select-PromotionCandidates" {
         }
     }
 }
+
+Describe "Select-ProductionDynamicWorkerRelease" {
+    Context "with no parameters" {
+        It "returns nothing" {
+            # Arrange
+            $releases = [Release[]] @()
+            $deployments = [Deployment[]] @()
+
+            # Act
+            $result = Select-ProductionDynamicWorkerRelease $releases $deployments
+            
+            # Assert
+            $result.Count | Should -Be 0
+        }
+    }
+}

--- a/EnthusiasticPromotions/enthusiastic-promotor.tests.ps1
+++ b/EnthusiasticPromotions/enthusiastic-promotor.tests.ps1
@@ -1,43 +1,49 @@
 using module .\enthusiastic-promotor.psm1
 
-$stagingEnvironment = "Environments-1"
-$prodEnvironment = "Environments-2"
-
 BeforeAll {
-    . .\enthusiastic-promotor.ps1 -targetProjectTestEnvironment $stagingEnvironment -targetProjectProdEnvironment $prodEnvironment
+    . .\enthusiastic-promotor.ps1
+    
+    $stagingEnvironment = "Environments-1"
+    $prodEnvironment = "Environments-2"
 }
 
 Describe "Get-PromotionCandidates" {
-    It "with no parameters returns nothing" {
-        # Act
-        $result = Get-PromotionCandidates ([Release[]] @()) ([Deployment[]] @())
+    Context "with no parameters" {
+        It "returns nothing" {
+            # Act
+            $result = Get-PromotionCandidates ([Release[]] @()) ([Deployment[]] @()) $stagingEnvironment $prodEnvironment
 
-        # Assert
-        $result.Count | Should -Be 0
+            # Assert
+            $result.Count | Should -Be 0
+        }
     }
 
-    It "with a Release and no Deployments returns nothing" {
-        # Arrange
-        $releases = [Release[]] @( [Release]::new("Release-1", "Project-1") )
-        $deployments = [Deployment[]] @()
-        
-        # Act
-        $result = Get-PromotionCandidates $releases $deployments
+    Context "with a Release and no Deployments" {
+        It "returns nothing" {
+            # Arrange
+            $releases = [Release[]] @( [Release]::new("Release-1", "Project-1") )
+            $deployments = [Deployment[]] @()
+            
+            # Act
+            $result = Get-PromotionCandidates $releases $deployments $stagingEnvironment $prodEnvironment
 
-        # Assert
-        $result.Count | Should -Be 0
+            # Assert
+            $result.Count | Should -Be 0
+        }
     }
 
-    It "with no Releases and a Deployment returns nothing" {
-        # Arrange
-        $releases = [Release[]] @()
-        $deployments = [Deployment[]] @( [Deployment]::new("Deployment-1", "Release-1", "Project-1") )
-        
-        # Act
-        $result = Get-PromotionCandidates $releases $deployments
+    Context "with no Releases and a Deployment" {
+        It "returns nothing" {
+            # Arrange
+            $releases = [Release[]] @()
+            $deployments = [Deployment[]] @( [Deployment]::new("Deployment-1", "Release-1", "Project-1") )
+            
+            # Act
+            $result = Get-PromotionCandidates $releases $deployments $stagingEnvironment $prodEnvironment
 
-        # Assert
-        $result.Count | Should -Be 0
+            # Assert
+            $result.Count | Should -Be 0
+        }
     }
 
     It "ignores already promoted Releases" {
@@ -49,7 +55,7 @@ Describe "Get-PromotionCandidates" {
         )
 
         # Act
-        $result = Get-PromotionCandidates $releases $deployments
+        $result = Get-PromotionCandidates $releases $deployments $stagingEnvironment $prodEnvironment
 
         # Assert
         $result.Count | Should -Be 0
@@ -69,7 +75,7 @@ Describe "Get-PromotionCandidates" {
         )
 
         # Act
-        $result = Get-PromotionCandidates $releases $deployments
+        $result = Get-PromotionCandidates $releases $deployments $stagingEnvironment $prodEnvironment
 
         # Assert
         $result.Count | Should -Be 1
@@ -93,7 +99,7 @@ Describe "Get-PromotionCandidates" {
         )
 
         # Act
-        $result = Get-PromotionCandidates $releases $deployments
+        $result = Get-PromotionCandidates $releases $deployments $stagingEnvironment $prodEnvironment
 
         # Assert
         $result.Count | Should -Be 1

--- a/EnthusiasticPromotions/enthusiastic-promotor.tests.ps1
+++ b/EnthusiasticPromotions/enthusiastic-promotor.tests.ps1
@@ -1,5 +1,10 @@
+using module .\enthusiastic-promotor.psm1
+
+$stagingEnvironment = "Environments-1"
+$prodEnvironment = "Environments-2"
+
 BeforeAll {
-    . (Join-Path -Path $PSScriptRoot -ChildPath "enthusiastic-promotor.ps1")
+    . .\enthusiastic-promotor.ps1 -targetProjectTestEnvironment $stagingEnvironment -targetProjectProdEnvironment $prodEnvironment
 }
 
 Describe "Get-PromotionCandidates" {

--- a/EnthusiasticPromotions/enthusiastic-promotor.tests.ps1
+++ b/EnthusiasticPromotions/enthusiastic-promotor.tests.ps1
@@ -7,11 +7,11 @@ BeforeAll {
     $prodEnvironment = "Environments-2"
 }
 
-Describe "Get-PromotionCandidates" {
+Describe "Select-PromotionCandidates" {
     Context "with no parameters" {
         It "returns nothing" {
             # Act
-            $result = Get-PromotionCandidates ([Release[]] @()) ([Deployment[]] @()) $stagingEnvironment $prodEnvironment
+            $result = Select-PromotionCandidates ([Release[]] @()) ([Deployment[]] @()) $stagingEnvironment $prodEnvironment
 
             # Assert
             $result.Count | Should -Be 0
@@ -25,7 +25,7 @@ Describe "Get-PromotionCandidates" {
             $deployments = [Deployment[]] @()
             
             # Act
-            $result = Get-PromotionCandidates $releases $deployments $stagingEnvironment $prodEnvironment
+            $result = Select-PromotionCandidates $releases $deployments $stagingEnvironment $prodEnvironment
 
             # Assert
             $result.Count | Should -Be 0
@@ -39,7 +39,7 @@ Describe "Get-PromotionCandidates" {
             $deployments = [Deployment[]] @( [Deployment]::new("Deployment-1", "Release-1", "Project-1") )
             
             # Act
-            $result = Get-PromotionCandidates $releases $deployments $stagingEnvironment $prodEnvironment
+            $result = Select-PromotionCandidates $releases $deployments $stagingEnvironment $prodEnvironment
 
             # Assert
             $result.Count | Should -Be 0
@@ -55,7 +55,7 @@ Describe "Get-PromotionCandidates" {
             )
 
             # Act
-            $result = Get-PromotionCandidates $releases $deployments $stagingEnvironment $prodEnvironment
+            $result = Select-PromotionCandidates $releases $deployments $stagingEnvironment $prodEnvironment
 
             # Assert
             $result.Count | Should -Be 0
@@ -75,7 +75,7 @@ Describe "Get-PromotionCandidates" {
             )
 
             # Act
-            $result = Get-PromotionCandidates $releases $deployments $stagingEnvironment $prodEnvironment
+            $result = Select-PromotionCandidates $releases $deployments $stagingEnvironment $prodEnvironment
 
             # Assert
             $result.Count | Should -Be 1
@@ -99,7 +99,7 @@ Describe "Get-PromotionCandidates" {
             )
 
             # Act
-            $result = Get-PromotionCandidates $releases $deployments $stagingEnvironment $prodEnvironment
+            $result = Select-PromotionCandidates $releases $deployments $stagingEnvironment $prodEnvironment
 
             # Assert
             $result.Count | Should -Be 1

--- a/EnthusiasticPromotions/enthusiastic-promotor.tests.ps1
+++ b/EnthusiasticPromotions/enthusiastic-promotor.tests.ps1
@@ -1,125 +1,126 @@
-using module .\enthusiastic-promotor.psm1
-
 BeforeAll {
-    . .\enthusiastic-promotor.ps1
-    
-    $stagingEnvironment = "Environments-1"
-    $prodEnvironment = "Environments-2"
+    . $PSScriptRoot/enthusiastic-promotor.ps1
+
+    $stagingEnvironmentId = "Environments-1"
+    $prodEnvironmentId = "Environments-2"
+
+    function New-Release($releaseId, $projectId, $version, $created) { 
+        return New-Object PSObject -Property @{ 
+            ReleaseId = $releaseId
+            ProjectId = $projectId
+            Version = $version
+            Created = $created
+        } 
+    }
+
+    function New-Deployment($deploymentId, $releaseId, $environmentId) {
+        return New-Object PSObject -Property @{ 
+            DeploymentId = $deploymentId
+            ReleaseId = $releaseId
+            EnvironmentId = $environmentId 
+        } 
+    }
 }
 
 Describe "Select-PromotionCandidates" {
-    Context "with no parameters" {
-        It "returns nothing" {
-            # Act
-            $result = Select-PromotionCandidates ([Release[]] @()) ([Deployment[]] @()) $stagingEnvironment $prodEnvironment
+    It "ignores already promoted Releases" {
+        # Arrange
+        $releases = New-Release "Release-1" "Project-1" "0.0.1"
+        $deployments = @( 
+            New-Deployment "Deployment-1" "Release-1" $stagingEnvironmentId
+            New-Deployment "Deployment-2" "Release-1" $prodEnvironmentId
+        )
 
-            # Assert
-            $result.Count | Should -Be 0
-        }
+        # Act
+        $result = @(Select-PromotionCandidates $releases $deployments $stagingEnvironmentId $prodEnvironmentId)
+
+        # Assert
+        $result.Count | Should -Be 0
     }
 
-    Context "with a Release and no Deployments" {
-        It "returns nothing" {
-            # Arrange
-            $releases = [Release[]] @( [Release]::new("Release-1", "Project-1") )
-            $deployments = [Deployment[]] @()
-            
-            # Act
-            $result = Select-PromotionCandidates $releases $deployments $stagingEnvironment $prodEnvironment
+    It "includes unpromoted Releases" {
+        # Arrange
+        $releases = @( 
+            New-Release "Release-1" "Project-1" "0.0.1"
+            New-Release "Release-2" "Project-1" "0.0.2"
+        )
+        $deployments = @( 
+            New-Deployment "Deployment-1" "Release-1" $stagingEnvironmentId
+            New-Deployment "Deployment-2" "Release-1" $prodEnvironmentId
+            New-Deployment "Deployment-3" "Release-2" $stagingEnvironmentId
+        )
 
-            # Assert
-            $result.Count | Should -Be 0
-        }
+        # Act
+        $result = @(Select-PromotionCandidates $releases $deployments $stagingEnvironmentId $prodEnvironmentId)
+
+        # Assert
+        $result.Count | Should -Be 1
+        $result[0].ReleaseId | Should -Be "Release-2"
     }
 
-    Context "with no Releases and a Deployment" {
-        It "returns nothing" {
-            # Arrange
-            $releases = [Release[]] @()
-            $deployments = [Deployment[]] @( [Deployment]::new("Deployment-1", "Release-1", "Project-1") )
-            
-            # Act
-            $result = Select-PromotionCandidates $releases $deployments $stagingEnvironment $prodEnvironment
+    It "excludes superseded unpromoted Releases" {
+        # Arrange
+        $releases = @( 
+            New-Release "Release-1" "Project-1" "0.0.1" [DateTime]::Now.AddDays(-10)
+            New-Release "Release-2" "Project-1" "0.0.2" [DateTime]::Now.AddDays(-7)
+            New-Release "Release-3" "Project-1" "0.0.3" [DateTime]::Now.AddDays(-3)
+        )
+        $deployments = @( 
+            New-Deployment "Deployment-1" "Release-1" $stagingEnvironmentId
 
-            # Assert
-            $result.Count | Should -Be 0
-        }
-    }
-    Context "with valid Releases and Deployments" {
-        It "ignores already promoted Releases" {
-            # Arrange
-            $releases = [Release[]] @( [Release]::new("Release-1", "Project-1") )
-            $deployments = [Deployment[]] @( 
-                [Deployment]::new("Deployment-1", "Release-1", $stagingEnvironment)
-                [Deployment]::new("Deployment-2", "Release-1", $prodEnvironment)
-            )
+            New-Deployment "Deployment-2" "Release-2" $stagingEnvironmentId
+            New-Deployment "Deployment-3" "Release-2" $prodEnvironmentId
+            New-Deployment "Deployment-4" "Release-3" $stagingEnvironmentId
+        )
 
-            # Act
-            $result = Select-PromotionCandidates $releases $deployments $stagingEnvironment $prodEnvironment
+        # Act
+        $result = @(Select-PromotionCandidates $releases $deployments $stagingEnvironmentId $prodEnvironmentId)
 
-            # Assert
-            $result.Count | Should -Be 0
-        }
-
-        It "includes unpromoted Releases" {
-            # Arrange
-            $releases = [Release[]] @( 
-                [Release]::new("Release-1", "Project-1")
-                [Release]::new("Release-2", "Project-1")
-            )
-            $deployments = [Deployment[]] @( 
-                [Deployment]::new("Deployment-1", "Release-1", $stagingEnvironment)
-                [Deployment]::new("Deployment-2", "Release-1", $prodEnvironment)
-
-                [Deployment]::new("Deployment-3", "Release-2", $stagingEnvironment)
-            )
-
-            # Act
-            $result = Select-PromotionCandidates $releases $deployments $stagingEnvironment $prodEnvironment
-
-            # Assert
-            $result.Count | Should -Be 1
-            $result[0].ReleaseId | Should -Be "Release-2"
-        }
-
-        It "excludes superseded unpromoted Releases" {
-            # Arrange
-            $releases = [Release[]] @( 
-                [Release]::new("Release-1", "Project-1", [DateTime]::Now.AddDays(-10))
-                [Release]::new("Release-2", "Project-1", [DateTime]::Now.AddDays(-7))
-                [Release]::new("Release-3", "Project-1", [DateTime]::Now.AddDays(-3))
-            )
-            $deployments = [Deployment[]] @( 
-                [Deployment]::new("Deployment-1", "Release-1", $stagingEnvironment)
-
-                [Deployment]::new("Deployment-2", "Release-2", $stagingEnvironment)
-                [Deployment]::new("Deployment-3", "Release-2", $prodEnvironment)
-
-                [Deployment]::new("Deployment-4", "Release-3", $stagingEnvironment)
-            )
-
-            # Act
-            $result = Select-PromotionCandidates $releases $deployments $stagingEnvironment $prodEnvironment
-
-            # Assert
-            $result.Count | Should -Be 1
-            $result[0].ReleaseId | Should -Be "Release-3"
-        }
+        # Assert
+        $result.Count | Should -Be 1
+        $result[0].ReleaseId | Should -Be "Release-3"
     }
 }
 
-Describe "Select-ProductionDynamicWorkerRelease" {
-    Context "with no parameters" {
-        It "returns nothing" {
-            # Arrange
-            $releases = [Release[]] @()
-            $deployments = [Deployment[]] @()
+Describe "Select-CommonCachedVersions" {
+    It "selects the intersection of cached versions lists" {
+        # Arrange
+        $cachedVersionLists = @(
+            , @("0.0.1-ubuntu.18.04", "0.0.2-ubuntu.18.04")
+            , @("0.0.2-ubuntu.18.04", "0.0.3-ubuntu.18.04")
+            , @("0.0.2-ubuntu.18.04", "0.0.4-ubuntu.18.04")
+        )
 
-            # Act
-            $result = Select-ProductionDynamicWorkerRelease $releases $deployments
-            
-            # Assert
-            $result.Count | Should -Be 0
-        }
+        # Act
+        $result = @(Select-CommonCachedVersions $cachedVersionLists)
+
+        # Assert
+        $result.Count | Should -Be 1
+        $result[0] | Should -Be "0.0.2-ubuntu.18.04"
+    }
+}
+
+Describe "Select-CachedCandidates" {
+    It "selects candidates that are cached in production" {
+        # Arrange
+        $release2 = New-Release "Releases-2" "Projects-1" "0.0.2"
+        $release3 = New-Release "Releases-3" "Projects-1" "0.0.3"
+        $release4 = New-Release "Releases-4" "Projects-1" "0.0.4"
+
+        $promotionCandidates = @($release2, $release3, $release4)
+
+        $cachedWorkerToolsVersions = @(
+            "0.0.1-ubuntu.18.04"
+            "0.0.2-ubuntu.18.04"
+            "0.0.3-ubuntu.18.04"
+        )
+
+        # Act
+        $result = Select-CachedCandidates $promotionCandidates $cachedWorkerToolsVersions "ubuntu.18.04"
+
+        # Assert
+        $result.Count | Should -Be 2
+        $release2 | Should -BeIn $result
+        $release3 | Should -BeIn $result
     }
 }

--- a/EnthusiasticPromotions/enthusiastic-promotor.tests.ps1
+++ b/EnthusiasticPromotions/enthusiastic-promotor.tests.ps1
@@ -4,7 +4,34 @@ BeforeAll {
 
 Describe "Get-PromotionCandidates" {
     It "with no parameters returns nothing" {
-        $result = Get-PromotionCandidates
+        # Act
+        $result = Get-PromotionCandidates ([Release[]] @()) ([Deployment[]] @())
+
+        # Assert
+        $result.Count | Should -Be 0
+    }
+
+    It "with a Release and no Deployments returns nothing" {
+        # Arrange
+        $releases = [Release[]] @( [Release]::new("Release-1", "Project-1") )
+        $deployments = [Deployment[]] @()
+        
+        # Act
+        $result = Get-PromotionCandidates $releases $deployments
+
+        # Assert
+        $result.Count | Should -Be 0
+    }
+
+    It "with no Releases and a Deployment returns nothing" {
+        # Arrange
+        $releases = [Release[]] @()
+        $deployments = [Deployment[]] @( [Deployment]::new("Deployment-1", "Release-1", "Project-1") )
+        
+        # Act
+        $result = Get-PromotionCandidates $releases $deployments
+
+        # Assert
         $result.Count | Should -Be 0
     }
 }


### PR DESCRIPTION
This PR introduces a PowerShell script which can perform Enthusiastic Promotion for Worker Tools images, by:

1. [Done] Finding any unpromoted releases ("promotion candidates") in the target Octopus project
1. [To-do] Determining which images are currently cached on the Production Dynamic Workers, by:
  a. Finding the most recent fully-promoted Dynamic Worker image (promoted to all Octopus Cloud regions)
  b. Determining which docker images are cached on that Dynamic Worker image, by cross-referencing its deployment artifacts
1. [To-do] Filtering out any promotion candidates whose corresponding docker image is not cached on the current Dynamic Worker image

Once the candidate releases have been filtered down to those that are fully cached on the Dynamic Workers, we trigger a promotion of the candidate to Production, making it available to customers on DockerHub.