### PR TITLE
Bump dotnet sdk version

### DIFF
--- a/ubuntu.18.04/Dockerfile
+++ b/ubuntu.18.04/Dockerfile
@@ -5,7 +5,7 @@ ARG Aws_Iam_Authenticator_Version=0.5.3
 ARG Aws_Powershell_Version=4.1.2
 ARG Azure_Cli_Version=2.14.0\*
 ARG Azure_Powershell_Version=4.5.0
-ARG Dotnet_Sdk_Version=3.1.401-1
+ARG Dotnet_Sdk_Version=6.0
 ARG Ecs_Cli_Version=1.20.0
 ARG Eks_Cli_Version=0.25.0
 ARG Google_Cloud_Cli_Version=339.0.0-0
@@ -56,13 +56,13 @@ RUN pwsh -c 'Install-Module -Force -Name Az -AllowClobber -Scope AllUsers -Maxim
 # Get Helm3
 RUN wget --quiet -O - https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash -s -- -v ${Helm_Version}
 
-# Get .NET SDK 3.1
+# Get .NET SDK 6.0
 # https://docs.microsoft.com/en-us/dotnet/core/install/linux-package-manager-ubuntu-1804
 RUN DOTNET_CLI_TELEMETRY_OPTOUT=1 && \
     echo "export DOTNET_CLI_TELEMETRY_OPTOUT=1" > /etc/profile.d/set-dotnet-env-vars.sh && \
     apt-get install -y apt-transport-https && \
     apt-get update && \
-    apt-get install -y dotnet-sdk-3.1
+    apt-get install -y ${Dotnet_Sdk_Version}
 
 # Get JDK
 # https://www.digitalocean.com/community/tutorials/how-to-install-java-with-apt-on-ubuntu-18-04

--- a/ubuntu.18.04/Dockerfile
+++ b/ubuntu.18.04/Dockerfile
@@ -62,7 +62,7 @@ RUN DOTNET_CLI_TELEMETRY_OPTOUT=1 && \
     echo "export DOTNET_CLI_TELEMETRY_OPTOUT=1" > /etc/profile.d/set-dotnet-env-vars.sh && \
     apt-get install -y apt-transport-https && \
     apt-get update && \
-    apt-get install -y ${Dotnet_Sdk_Version}
+    apt-get install -y dotnet-sdk-${Dotnet_Sdk_Version}
 
 # Get JDK
 # https://www.digitalocean.com/community/tutorials/how-to-install-java-with-apt-on-ubuntu-18-04

--- a/ubuntu.18.04/README.md
+++ b/ubuntu.18.04/README.md
@@ -1,5 +1,8 @@
 # Ubuntu WorkerTools
 
+> Please note that we update this document periodically to match the latest version on DockerHub which is publicly available.
+> This does not necessarily match the content of Dockerfiles in this repository, as they may contain changes that are not released yet.
+
 ## Image Name
 `octopusdeploy/worker-tools`
 

--- a/ubuntu.18.04/spec/ubuntu.18.04.tests.ps1
+++ b/ubuntu.18.04/spec/ubuntu.18.04.tests.ps1
@@ -13,7 +13,7 @@ Describe  'installed dependencies' {
     }
 
     It 'has dotnet installed' {
-        dotnet --version | Should -match '3.1.\d+'
+        dotnet --version | Should -match '6.0.\d+'
         $LASTEXITCODE | Should -be 0
     }
 

--- a/windows.ltsc2019/Dockerfile
+++ b/windows.ltsc2019/Dockerfile
@@ -31,7 +31,7 @@ RUN $ProgressPreference = 'SilentlyContinue'; `
 # Install dotnet 3.1+
 RUN Invoke-WebRequest 'https://dot.net/v1/dotnet-install.ps1' -outFile 'dotnet-install.ps1'; `
     [Environment]::SetEnvironmentVariable('DOTNET_CLI_TELEMETRY_OPTOUT', '1', 'Machine'); `
-    .\dotnet-install.ps1 -Channel '3.1'; `
+    .\dotnet-install.ps1 -Channel '6.0'; `
     rm dotnet-install.ps1
 
 # Install JDK

--- a/windows.ltsc2019/README.md
+++ b/windows.ltsc2019/README.md
@@ -1,5 +1,8 @@
 # Windows WorkerTools
 
+> Please note that we update this document periodically to match the latest version on DockerHub which is publicly available.
+> This does not necessarily match the content of Dockerfiles in this repository, as they may contain changes that are not released yet.
+
 ## Image Name
 `octopusdeploy/worker-tools`
 

--- a/windows.ltsc2019/spec/windows.ltsc2019.tests.ps1
+++ b/windows.ltsc2019/spec/windows.ltsc2019.tests.ps1
@@ -17,7 +17,7 @@ Describe  'installed dependencies' {
     }
 
     It 'has dotnet installed' {
-        dotnet --version | Should -Match '3.1.\d+'
+        dotnet --version | Should -Match '6.0.\d+'
         $LASTEXITCODE | Should -be 0
     }
 


### PR DESCRIPTION
[sc-11764] (internal link)

This PR bumps the version of dotnet sdk from 3.1 to 6.0, since [DotNet Core 3.1 is reaching its end of support](https://devblogs.microsoft.com/dotnet/net-core-3-1-will-reach-end-of-support-on-december-13-2022/).

The README files have also been updated to avoid confusion.