### PR TITLE
Update windows image containing dotnet 4.8 runtime

### DIFF
--- a/windows.ltsc2019/Dockerfile
+++ b/windows.ltsc2019/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019
 SHELL ["powershell", "-Command"]
 
 ARG Aws_Cli_Version=2.0.60


### PR DESCRIPTION
Updates image to use the [dotnet-framework-docker image]( https://github.com/microsoft/dotnet-framework-docker) which is baked with 4.8 runtime. This is required in order to support the Calamari flavours to net48 when a deployment is ran inside a container.

See the support policy here.
https://mcr.microsoft.com/en-us/product/dotnet/framework/runtime/about