### PR TITLE
Updating Octopus.Client & adding support for Octopus.Server.Client

### DIFF
--- a/ubuntu.18.04/spec/ubuntu.18.04.tests.ps1
+++ b/ubuntu.18.04/spec/ubuntu.18.04.tests.ps1
@@ -8,7 +8,7 @@ Write-Host 'Running tests with Pester v'+$($pesterModules[0].Version)
 
 Describe  'installed dependencies' {
     It 'has Octopus.Client installed ' {
-        $expectedVersion = "8.8.3"
+        $expectedVersion = "11.6.3644"
         [Reflection.AssemblyName]::GetAssemblyName("/Octopus.Client.dll").Version.ToString() | Should -match "$expectedVersion.0"
     }
 

--- a/ubuntu.22.04/Dockerfile
+++ b/ubuntu.22.04/Dockerfile
@@ -79,9 +79,9 @@ RUN apt-get update && \
     apt-get install -y maven gradle
 
 # Get Libssl 1.1, required for Azure CLI as of Ubuntu 22.04. This can be removed when a proper Azure CLI ubuntu 22.04 version is avaliable
-RUN wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb && \
-    dpkg -i ./libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb && \
-    rm -i libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
+RUN wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb && \
+    dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb && \
+    rm -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb
 
 # Get Azure CLI
 # https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-apt?view=azure-cli-latest

--- a/ubuntu.22.04/Dockerfile
+++ b/ubuntu.22.04/Dockerfile
@@ -49,7 +49,7 @@ RUN pwsh -c 'Install-Package -Force Octopus.Client -MaximumVersion "'${Octopus_C
 
 RUN pwsh -c 'Install-Package -Force Octopus.Server.Client -MaximumVersion "'${Octopus_Client_Version}'" -source https://www.nuget.org/api/v2 -SkipDependencies' && \
     octopusServerClientPackagePath=$(pwsh -c '(Get-Item ((Get-Package Octopus.Server.Client).source)).Directory.FullName') && \
-    cp -r octopusServerClientPackagePath/lib/netstandard2.0/* .
+    cp -r $octopusServerClientPackagePath/lib/netstandard2.0/* .
 
 # Get AWS Powershell core modules
 # https://docs.aws.amazon.com/powershell/latest/userguide/pstools-getting-set-up-linux-mac.html

--- a/ubuntu.22.04/Dockerfile
+++ b/ubuntu.22.04/Dockerfile
@@ -14,7 +14,7 @@ ARG Helm_Version=v3.7.1
 ARG Java_Jdk_Version=11.0.17+8-1ubuntu2~22.04
 ARG Kubectl_Version=1.18.8-00
 ARG Octopus_Cli_Version=9.1.7
-ARG Octopus_Client_Version=8.8.3
+ARG Octopus_Client_Version=11.6.3644
 ARG Powershell_Version=7.2.7-1.deb
 ARG Terraform_Version=1.1.3
 ARG Umoci_Version=0.4.6
@@ -45,7 +45,11 @@ RUN apt-get update && \
 # https://octopus.com/docs/octopus-rest-api/octopus.client
 RUN pwsh -c 'Install-Package -Force Octopus.Client -MaximumVersion "'${Octopus_Client_Version}'" -source https://www.nuget.org/api/v2 -SkipDependencies' && \
     octopusClientPackagePath=$(pwsh -c '(Get-Item ((Get-Package Octopus.Client).source)).Directory.FullName') && \
-    cp -r $octopusClientPackagePath/lib/netstandard2.0/* .
+    cp -r $octopusClientPackagePath/lib/netstandard2.0/* . 
+
+RUN pwsh -c 'Install-Package -Force Octopus.Server.Client -MaximumVersion "'${Octopus_Client_Version}'" -source https://www.nuget.org/api/v2 -SkipDependencies' && \
+    octopusServerClientPackagePath=$(pwsh -c '(Get-Item ((Get-Package Octopus.Server.Client).source)).Directory.FullName') && \
+    cp -r octopusServerClientPackagePath/lib/netstandard2.0/* .
 
 # Get AWS Powershell core modules
 # https://docs.aws.amazon.com/powershell/latest/userguide/pstools-getting-set-up-linux-mac.html

--- a/ubuntu.22.04/README.md
+++ b/ubuntu.22.04/README.md
@@ -34,7 +34,8 @@
 * Java Jdk 11.0.17+8-1ubuntu2~22.04
 * Kubectl 1.18.8-00
 * Octopus CLI 9.1.7
-* Octopus Client 8.8.3
+* Octopus Client 11.6.3644
+* Octopus Server Client 11.6.3644
 * Powershell 7.2.7-1.deb
 * Terraform 1.1.3
 * Umoci 0.4.6

--- a/ubuntu.22.04/spec/ubuntu.22.04.tests.ps1
+++ b/ubuntu.22.04/spec/ubuntu.22.04.tests.ps1
@@ -8,8 +8,13 @@ Write-Host 'Running tests with Pester v'+$($pesterModules[0].Version)
 
 Describe  'installed dependencies' {
     It 'has Octopus.Client installed ' {
-        $expectedVersion = "8.8.3"
+        $expectedVersion = "11.6.3644"
         [Reflection.AssemblyName]::GetAssemblyName("/Octopus.Client.dll").Version.ToString() | Should -match "$expectedVersion.0"
+    }
+
+    It 'has Octopus.Server.Client installed ' {
+        $expectedVersion = "11.6.3644"
+        [Reflection.AssemblyName]::GetAssemblyName("/Octopus.Server.Client.dll").Version.ToString() | Should -match "$expectedVersion.0"
     }
 
     It 'has dotnet installed' {

--- a/windows.ltsc2019/Dockerfile
+++ b/windows.ltsc2019/Dockerfile
@@ -15,7 +15,7 @@ ARG Java_Jdk_Version=14.0.2
 ARG Kubectl_Version=1.18.8
 ARG Node_Version=14.17.2
 ARG Octopus_Cli_Version=9.1.7
-ARG Octopus_Client_Version=8.8.3
+ARG Octopus_Client_Version=11.6.3644
 ARG Powershell_Version=7.2.7
 ARG Python_Version=3.8.5
 ARG ScriptCs_Version=0.17.1
@@ -91,6 +91,7 @@ RUN choco install octopustools -y --version $Env:Octopus_Cli_Version --no-progre
 
 # # Install Octopus Client
 RUN Install-Package Octopus.Client -source https://www.nuget.org/api/v2 -SkipDependencies -Force -RequiredVersion $Env:Octopus_Client_Version
+RUN Install-Package Octopus.Server.Client -source https://www.nuget.org/api/v2 -SkipDependencies -Force -RequiredVersion $Env:Octopus_Server_Client_Version
 
 # # Install eksctl
 RUN choco install eksctl -y --version $Env:Eks_Cli_Version --no-progress

--- a/windows.ltsc2019/Dockerfile
+++ b/windows.ltsc2019/Dockerfile
@@ -91,7 +91,7 @@ RUN choco install octopustools -y --version $Env:Octopus_Cli_Version --no-progre
 
 # # Install Octopus Client
 RUN Install-Package Octopus.Client -source https://www.nuget.org/api/v2 -SkipDependencies -Force -RequiredVersion $Env:Octopus_Client_Version
-RUN Install-Package Octopus.Server.Client -source https://www.nuget.org/api/v2 -SkipDependencies -Force -RequiredVersion $Env:Octopus_Server_Client_Version
+RUN Install-Package Octopus.Server.Client -source https://www.nuget.org/api/v2 -SkipDependencies -Force -RequiredVersion $Env:Octopus_Client_Version
 
 # # Install eksctl
 RUN choco install eksctl -y --version $Env:Eks_Cli_Version --no-progress

--- a/windows.ltsc2019/README.md
+++ b/windows.ltsc2019/README.md
@@ -33,7 +33,8 @@
 * Kubectl 1.18.8
 * Node 14.17.2
 * Octopus CLI 9.1.7
-* Octopus Client 8.8.3
+* Octopus Client 11.6.3644
+* Octopus Server Client 11.6.3644
 * Powershell 7.2.7
 * Python 3.8.5
 * ScriptCs 0.17.1

--- a/windows.ltsc2019/spec/windows.ltsc2019.tests.ps1
+++ b/windows.ltsc2019/spec/windows.ltsc2019.tests.ps1
@@ -11,8 +11,14 @@ Describe  'installed dependencies' {
     }
 
     It 'has Octopus.Client installed ' {
-        $expectedVersion = "8.8.3"
+        $expectedVersion = "11.6.3644"
         Test-Path "C:\Program Files\PackageManagement\NuGet\Packages\Octopus.Client.$expectedVersion\lib\net452\Octopus.Client.dll" | Should -Be $true
+        [Reflection.AssemblyName]::GetAssemblyName("C:\Program Files\PackageManagement\NuGet\Packages\Octopus.Client.$expectedVersion\lib\net452\Octopus.Client.dll").Version.ToString() | Should -Match "$expectedVersion.0"
+    }
+
+    It 'has Octopus.Server.Client installed ' {
+        $expectedVersion = "11.6.3644"
+        Test-Path "C:\Program Files\PackageManagement\NuGet\Packages\Octopus.Server.Client.$expectedVersion\lib\net452\Octopus.Server.Client.dll" | Should -Be $true
         [Reflection.AssemblyName]::GetAssemblyName("C:\Program Files\PackageManagement\NuGet\Packages\Octopus.Client.$expectedVersion\lib\net452\Octopus.Client.dll").Version.ToString() | Should -Match "$expectedVersion.0"
     }
 


### PR DESCRIPTION
Octopus.Client was historically added to Worker Tools primarily for types in PowerShell scripting. Since then, Octopus.Server.Client has taken its place in the OctopusCLI and has now been added. Octopus.Client is kept for backward compatibility.