### PR TITLE
Remove Octopus.Server.Client, update Octopus.Client path for windows images

### DIFF
--- a/ubuntu.22.04/Dockerfile
+++ b/ubuntu.22.04/Dockerfile
@@ -47,10 +47,6 @@ RUN pwsh -c 'Install-Package -Force Octopus.Client -MaximumVersion "'${Octopus_C
     octopusClientPackagePath=$(pwsh -c '(Get-Item ((Get-Package Octopus.Client).source)).Directory.FullName') && \
     cp -r $octopusClientPackagePath/lib/netstandard2.0/* . 
 
-RUN pwsh -c 'Install-Package -Force Octopus.Server.Client -MaximumVersion "'${Octopus_Client_Version}'" -source https://www.nuget.org/api/v2 -SkipDependencies' && \
-    octopusServerClientPackagePath=$(pwsh -c '(Get-Item ((Get-Package Octopus.Server.Client).source)).Directory.FullName') && \
-    cp -r $octopusServerClientPackagePath/lib/netstandard2.0/* .
-
 # Get AWS Powershell core modules
 # https://docs.aws.amazon.com/powershell/latest/userguide/pstools-getting-set-up-linux-mac.html
 RUN pwsh -c 'Install-Module -Force -Name AWSPowerShell.NetCore -AllowClobber -Scope AllUsers -MaximumVersion "'${Aws_Powershell_Version}'"'

--- a/ubuntu.22.04/README.md
+++ b/ubuntu.22.04/README.md
@@ -4,6 +4,7 @@
 > This does not necessarily match the content of Dockerfiles in this repository, as they may contain changes that are not released yet.
 
 ## Image Name
+
 `octopusdeploy/worker-tools`
 
 ## Tags
@@ -14,47 +15,49 @@
 - `ubuntu.22.04`
 
 ## Digest
+
 `sha256:5f436f9068be4033309636340b6c9d45998617d89ff47eef00b20b0731645d9b`
 
 ## Base Image
+
 `ubuntu:22.04`
 
 ## Installed Software
-* Aws CLI 2.0.60
-* Aws Iam Authenticator 0.5.3
-* Aws Powershell 4.1.2
-* Azure CLI 2.44.1-1~bionic
-* Azure Powershell 4.5.0
-* Dotnet Sdk 3.1.401-1
-* Ecs CLI 1.20.0
-* Eks CTL 0.25.0
-* Google Cloud CLI 412.0.0-0
-* Google Cloud GKE auth plugin 412.0.0-0
-* Helm v3.7.1
-* Java Jdk 11.0.17+8-1ubuntu2~22.04
-* Kubectl 1.18.8-00
-* Octopus CLI 9.1.7
-* Octopus Client 11.6.3644
-* Octopus Server Client 11.6.3644
-* Powershell 7.2.7-1.deb
-* Terraform 1.1.3
-* Umoci 0.4.6
-* wget - Latest
-* unzip - Latest
-* apt-utils - Latest
-* curl - Latest
-* software-properties-common - Latest
-* maven - Latest
-* gradle - Latest
-* Node 14 - Latest
-* Python3 - Latest
-* groff - Latest
-* Istio CLI - Latest
-* Linkerd CLI - Latest
-* umoci - Latest
-* jq - Latest
-* yq - Latest
-* openssh-client - Latest
-* rsync - Latest
-* git - Latest
-* augeas-tools - Latest
+
+- Aws CLI 2.0.60
+- Aws Iam Authenticator 0.5.3
+- Aws Powershell 4.1.2
+- Azure CLI 2.44.1-1~bionic
+- Azure Powershell 4.5.0
+- Dotnet Sdk 3.1.401-1
+- Ecs CLI 1.20.0
+- Eks CTL 0.25.0
+- Google Cloud CLI 412.0.0-0
+- Google Cloud GKE auth plugin 412.0.0-0
+- Helm v3.7.1
+- Java Jdk 11.0.17+8-1ubuntu2~22.04
+- Kubectl 1.18.8-00
+- Octopus CLI 9.1.7
+- Octopus Client 11.6.3644
+- Powershell 7.2.7-1.deb
+- Terraform 1.1.3
+- Umoci 0.4.6
+- wget - Latest
+- unzip - Latest
+- apt-utils - Latest
+- curl - Latest
+- software-properties-common - Latest
+- maven - Latest
+- gradle - Latest
+- Node 14 - Latest
+- Python3 - Latest
+- groff - Latest
+- Istio CLI - Latest
+- Linkerd CLI - Latest
+- umoci - Latest
+- jq - Latest
+- yq - Latest
+- openssh-client - Latest
+- rsync - Latest
+- git - Latest
+- augeas-tools - Latest

--- a/ubuntu.22.04/spec/ubuntu.22.04.tests.ps1
+++ b/ubuntu.22.04/spec/ubuntu.22.04.tests.ps1
@@ -12,11 +12,6 @@ Describe  'installed dependencies' {
         [Reflection.AssemblyName]::GetAssemblyName("/Octopus.Client.dll").Version.ToString() | Should -match "$expectedVersion.0"
     }
 
-    It 'has Octopus.Server.Client installed ' {
-        $expectedVersion = "11.6.3644"
-        [Reflection.AssemblyName]::GetAssemblyName("/Octopus.Server.Client.dll").Version.ToString() | Should -match "$expectedVersion.0"
-    }
-
     It 'has dotnet installed' {
         dotnet --version | Should -match '6.0.\d+'
         $LASTEXITCODE | Should -be 0

--- a/windows.ltsc2019/Dockerfile
+++ b/windows.ltsc2019/Dockerfile
@@ -91,7 +91,6 @@ RUN choco install octopustools -y --version $Env:Octopus_Cli_Version --no-progre
 
 # # Install Octopus Client
 RUN Install-Package Octopus.Client -source https://www.nuget.org/api/v2 -SkipDependencies -Force -RequiredVersion $Env:Octopus_Client_Version
-RUN Install-Package Octopus.Server.Client -source https://www.nuget.org/api/v2 -SkipDependencies -Force -RequiredVersion $Env:Octopus_Client_Version
 
 # # Install eksctl
 RUN choco install eksctl -y --version $Env:Eks_Cli_Version --no-progress

--- a/windows.ltsc2019/README.md
+++ b/windows.ltsc2019/README.md
@@ -4,6 +4,7 @@
 > This does not necessarily match the content of Dockerfiles in this repository, as they may contain changes that are not released yet.
 
 ## Image Name
+
 `octopusdeploy/worker-tools`
 
 ## Tags
@@ -14,30 +15,32 @@
 - `windows.ltsc2019`
 
 ## Digest
+
 `sha256:59c770b38a8c5e3ec9e347a3155cd0e2748c46cb498d82bb855041d845b3b52f`
 
 ## Base Image
+
 `mcr.microsoft.com/windows/servercore:ltsc2019`
 
 ## Installed Software
-* Aws CLI 2.0.60
-* Aws Iam Authenticator 0.5.3
-* Aws Powershell 4.1.2
-* Azure CLI 2.44.0
-* Azure Powershell 4.5.0
-* Eks Ctl 0.25.0
-* Google Cloud CLI 412.0.0
-* Google Cloud GKE auth plugin 412.0.0-0
-* Helm 3.7.1
-* Java Jdk 14.0.2
-* Kubectl 1.18.8
-* Node 14.17.2
-* Octopus CLI 9.1.7
-* Octopus Client 11.6.3644
-* Octopus Server Client 11.6.3644
-* Powershell 7.2.7
-* Python 3.8.5
-* ScriptCs 0.17.1
-* Terraform 1.1.3
-* 7Zip 19.0
-* Chocolatey - Latest
+
+- Aws CLI 2.0.60
+- Aws Iam Authenticator 0.5.3
+- Aws Powershell 4.1.2
+- Azure CLI 2.44.0
+- Azure Powershell 4.5.0
+- Eks Ctl 0.25.0
+- Google Cloud CLI 412.0.0
+- Google Cloud GKE auth plugin 412.0.0-0
+- Helm 3.7.1
+- Java Jdk 14.0.2
+- Kubectl 1.18.8
+- Node 14.17.2
+- Octopus CLI 9.1.7
+- Octopus Client 11.6.3644
+- Powershell 7.2.7
+- Python 3.8.5
+- ScriptCs 0.17.1
+- Terraform 1.1.3
+- 7Zip 19.0
+- Chocolatey - Latest

--- a/windows.ltsc2019/scripts/update_path.cmd
+++ b/windows.ltsc2019/scripts/update_path.cmd
@@ -1,2 +1,2 @@
-setx /M path "%PATH%;C:\google-cloud-sdk\bin;C:\Users\ContainerAdministrator\AppData\Local\Microsoft\dotnet;C:\Program Files\PackageManagement\NuGet\Packages\Octopus.Client.8.8.3\lib\net452\Octopus.Client.dll"
+setx /M path "%PATH%;C:\google-cloud-sdk\bin;C:\Users\ContainerAdministrator\AppData\Local\Microsoft\dotnet;C:\Program Files\PackageManagement\NuGet\Packages\Octopus.Client.11.6.3644\lib\net452\Octopus.Client.dll"
 

--- a/windows.ltsc2019/spec/windows.ltsc2019.tests.ps1
+++ b/windows.ltsc2019/spec/windows.ltsc2019.tests.ps1
@@ -16,12 +16,6 @@ Describe  'installed dependencies' {
         [Reflection.AssemblyName]::GetAssemblyName("C:\Program Files\PackageManagement\NuGet\Packages\Octopus.Client.$expectedVersion\lib\net452\Octopus.Client.dll").Version.ToString() | Should -Match "$expectedVersion.0"
     }
 
-    It 'has Octopus.Server.Client installed ' {
-        $expectedVersion = "11.6.3644"
-        Test-Path "C:\Program Files\PackageManagement\NuGet\Packages\Octopus.Server.Client.$expectedVersion\lib\net452\Octopus.Server.Client.dll" | Should -Be $true
-        [Reflection.AssemblyName]::GetAssemblyName("C:\Program Files\PackageManagement\NuGet\Packages\Octopus.Client.$expectedVersion\lib\net452\Octopus.Client.dll").Version.ToString() | Should -Match "$expectedVersion.0"
-    }
-
     It 'has dotnet installed' {
         dotnet --version | Should -Match '6.0.\d+'
         $LASTEXITCODE | Should -be 0


### PR DESCRIPTION
Removing as Octopus.Server.Client is already included in Octopus.Client. See https://octopus.com/docs/octopus-rest-api/octopus.client/getting-started