### PR TITLE
Pinning windows base image for layer sharing

### DIFF
--- a/windows.ltsc2019/Dockerfile
+++ b/windows.ltsc2019/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019
+FROM mcr.microsoft.com/dotnet/framework/runtime:4.8-20230214-windowsservercore-ltsc2019
 SHELL ["powershell", "-Command"]
 
 ARG Aws_Cli_Version=2.0.60


### PR DESCRIPTION
Since moving to Windows 4.8 base image, we ran into caching issues due to the base layer not being shared. Previous images had a shared base layer and patches applied on top. This is no longer happening. This change pins to a specific version of the base image. This still applies patches and updates after the base layer.

[Internal thread](https://octopusdeploy.slack.com/archives/C03SG0LFJHX/p1689556212724959)

Worker Tools 5.1.0 image layers
![Worker Tools 5.1.0](https://github.com/OctopusDeploy/WorkerTools/assets/101079287/26b97f61-dfa8-45ea-a6a3-cca803db3094)

Image layers at the time of making this change, note the Install Updates patch version.
![This change](https://github.com/OctopusDeploy/WorkerTools/assets/101079287/1a726c69-4f63-4f55-adb2-f7d5de0730a2)

