### PR TITLE
Install azure-cli for jammy

### DIFF
--- a/ubuntu.22.04/Dockerfile
+++ b/ubuntu.22.04/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 ARG Aws_Cli_Version=2.0.60
 ARG Aws_Iam_Authenticator_Version=0.5.3
 ARG Aws_Powershell_Version=4.1.2
-ARG Azure_Cli_Version=2.51.0
+ARG Azure_Cli_Version=2.51.0-1~jammy
 ARG Azure_Powershell_Version=4.5.0
 ARG Dotnet_Sdk_Version=6.0
 ARG Ecs_Cli_Version=1.20.0

--- a/ubuntu.22.04/Dockerfile
+++ b/ubuntu.22.04/Dockerfile
@@ -80,7 +80,7 @@ RUN apt-get update && \
     apt-get install -y maven gradle
 
 # Get Azure CLI
-# https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-apt?view=azure-cli-latest
+# https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt#option-2-step-by-step-installation-instructions
 RUN mkdir -p /etc/apt/keyrings && \
     curl -sLS https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/keyrings/microsoft.gpg > /dev/null && \
     chmod go+r /etc/apt/keyrings/microsoft.gpg && \

--- a/ubuntu.22.04/Dockerfile
+++ b/ubuntu.22.04/Dockerfile
@@ -86,8 +86,7 @@ RUN mkdir -p /etc/apt/keyrings && \
     chmod go+r /etc/apt/keyrings/microsoft.gpg && \
     echo "deb [arch=`dpkg --print-architecture` signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ jammy main" | tee /etc/apt/sources.list.d/azure-cli.list && \
     apt-get update && \
-    apt-get install azure-cli && \
-    apt-get autoremove
+    apt-get install azure-cli=${Azure_Cli_Version}
 
 # Get NodeJS
 # https://websiteforstudents.com/how-to-install-node-js-10-11-12-on-ubuntu-16-04-18-04-via-apt-and-snap/\

--- a/ubuntu.22.04/Dockerfile
+++ b/ubuntu.22.04/Dockerfile
@@ -86,7 +86,7 @@ RUN mkdir -p /etc/apt/keyrings && \
     chmod go+r /etc/apt/keyrings/microsoft.gpg && \
     echo "deb [arch=`dpkg --print-architecture` signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ jammy main" | tee /etc/apt/sources.list.d/azure-cli.list && \
     apt-get update && \
-    apt-get install azure-cli=${Azure_Cli_Version}
+    apt-get install -y azure-cli=${Azure_Cli_Version}
 
 # Get NodeJS
 # https://websiteforstudents.com/how-to-install-node-js-10-11-12-on-ubuntu-16-04-18-04-via-apt-and-snap/\

--- a/ubuntu.22.04/Dockerfile
+++ b/ubuntu.22.04/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 ARG Aws_Cli_Version=2.0.60
 ARG Aws_Iam_Authenticator_Version=0.5.3
 ARG Aws_Powershell_Version=4.1.2
-ARG Azure_Cli_Version=2.44.1-1~bionic
+ARG Azure_Cli_Version=2.51.0
 ARG Azure_Powershell_Version=4.5.0
 ARG Dotnet_Sdk_Version=6.0
 ARG Ecs_Cli_Version=1.20.0
@@ -20,7 +20,6 @@ ARG Powershell_Version=7.2.7-1.deb
 ARG Terraform_Version=1.1.3
 ARG Umoci_Version=0.4.6
 ARG Python2_Version=2.7.18-3
-ARG Argocd_Version=2.8.0
 
 # get `wget` & software-properties-common
 # https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-linux?view=powershell-7#ubuntu-1804
@@ -80,17 +79,15 @@ RUN apt-get install -y openjdk-11-jdk-headless=${Java_Jdk_Version}
 RUN apt-get update && \
     apt-get install -y maven gradle
 
-# Get Libssl 1.1, required for Azure CLI as of Ubuntu 22.04. This can be removed when a proper Azure CLI ubuntu 22.04 version is avaliable
-RUN wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb && \
-    dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb && \
-    rm -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb
-
 # Get Azure CLI
 # https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-apt?view=azure-cli-latest
-RUN wget --quiet -O - https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null && \
-    echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ bionic main" | tee /etc/apt/sources.list.d/azure-cli.list && \
+RUN mkdir -p /etc/apt/keyrings && \
+    curl -sLS https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/keyrings/microsoft.gpg > /dev/null && \
+    chmod go+r /etc/apt/keyrings/microsoft.gpg && \
+    echo "deb [arch=`dpkg --print-architecture` signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ jammy main" | tee /etc/apt/sources.list.d/azure-cli.list && \
     apt-get update && \
-    apt-get install -y azure-cli=${Azure_Cli_Version}
+    apt-get install azure-cli && \
+    apt-get autoremove
 
 # Get NodeJS
 # https://websiteforstudents.com/how-to-install-node-js-10-11-12-on-ubuntu-16-04-18-04-via-apt-and-snap/\
@@ -183,7 +180,3 @@ RUN add-apt-repository -y ppa:rmescandon/yq && \
 RUN sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_22.04/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list" && \
     wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_22.04/Release.key -O- | apt-key add - && \
     apt-get update && apt-get install -y skopeo
-
-RUN curl -sSL -o argocd-linux-amd64 https://github.com/argoproj/argo-cd/releases/download/v${Argocd_Version}/argocd-linux-amd64 && \
-  install -m 555 argocd-linux-amd64 /usr/local/bin/argocd && \
-  rm argocd-linux-amd64

--- a/ubuntu.22.04/Dockerfile
+++ b/ubuntu.22.04/Dockerfile
@@ -20,6 +20,7 @@ ARG Powershell_Version=7.2.7-1.deb
 ARG Terraform_Version=1.1.3
 ARG Umoci_Version=0.4.6
 ARG Python2_Version=2.7.18-3
+ARG Argocd_Version=2.8.0
 
 # get `wget` & software-properties-common
 # https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-linux?view=powershell-7#ubuntu-1804

--- a/ubuntu.22.04/Dockerfile
+++ b/ubuntu.22.04/Dockerfile
@@ -180,3 +180,7 @@ RUN add-apt-repository -y ppa:rmescandon/yq && \
 RUN sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_22.04/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list" && \
     wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_22.04/Release.key -O- | apt-key add - && \
     apt-get update && apt-get install -y skopeo
+
+RUN curl -sSL -o argocd-linux-amd64 https://github.com/argoproj/argo-cd/releases/download/v${Argocd_Version}/argocd-linux-amd64 && \
+  install -m 555 argocd-linux-amd64 /usr/local/bin/argocd && \
+  rm argocd-linux-amd64

--- a/ubuntu.22.04/README.md
+++ b/ubuntu.22.04/README.md
@@ -27,7 +27,7 @@
 - Aws CLI 2.0.60
 - Aws Iam Authenticator 0.5.3
 - Aws Powershell 4.1.2
-- Azure CLI 2.44.1-1~bionic
+- Azure CLI 2.51.0-1~jammy
 - Azure Powershell 4.5.0
 - Dotnet Sdk 3.1.401-1
 - Ecs CLI 1.20.0

--- a/ubuntu.22.04/spec/ubuntu.22.04.tests.ps1
+++ b/ubuntu.22.04/spec/ubuntu.22.04.tests.ps1
@@ -28,7 +28,7 @@ Describe  'installed dependencies' {
 
     It 'has az installed' {
       $output = (& az version) | convertfrom-json
-      $output.'azure-cli' | Should -be '2.44.1'
+      $output.'azure-cli' | Should -be '2.51.0'
       $LASTEXITCODE | Should -be 0
     }
 

--- a/windows.ltsc2019/Dockerfile
+++ b/windows.ltsc2019/Dockerfile
@@ -6,7 +6,7 @@ SHELL ["powershell", "-Command"]
 ARG Aws_Cli_Version=2.0.60
 ARG Aws_Iam_Authenticator_Version=0.5.3
 ARG Aws_Powershell_Version=4.1.2
-ARG Azure_Cli_Version=2.44.0
+ARG Azure_Cli_Version=2.51.0
 ARG Azure_Powershell_Version=4.5.0
 ARG Eks_Cli_Version=0.25.0
 ARG Google_Cloud_Cli_Version=412.0.0

--- a/windows.ltsc2019/README.md
+++ b/windows.ltsc2019/README.md
@@ -27,7 +27,7 @@
 - Aws CLI 2.0.60
 - Aws Iam Authenticator 0.5.3
 - Aws Powershell 4.1.2
-- Azure CLI 2.44.0
+- Azure CLI 2.51.0
 - Azure Powershell 4.5.0
 - Eks Ctl 0.25.0
 - Google Cloud CLI 412.0.0

--- a/windows.ltsc2019/spec/windows.ltsc2019.tests.ps1
+++ b/windows.ltsc2019/spec/windows.ltsc2019.tests.ps1
@@ -28,7 +28,7 @@ Describe  'installed dependencies' {
 
     It 'has az installed' {
       $output = (& az version) | convertfrom-json
-      $output.'azure-cli' | Should -Be '2.44.0'
+      $output.'azure-cli' | Should -Be '2.51.0'
       $LASTEXITCODE | Should -be 0
     }
     


### PR DESCRIPTION
For a long time the azure-cli was incredibly [bloated](https://github.com/Azure/azure-cli/issues/7387). As of earlier this year, and version `2.48.0`, significant size optimization had been [introduced](https://github.com/Azure/azure-cli/pull/26172). This compared to previous bloated versions has a reduction of > 0.5G.

This PR installs azure-cli from the proper `jammy` channel (which wasn't available before) and bumps it all the way to the latest, i.e. `2.51.0`, with the understanding that should anything go wrong, users still have the previous versions to choose from which will buy us time to release a fix.