### PR TITLE
Bump step template

### DIFF
--- a/.octopus/ubuntu.18.04/deployment_process.ocl
+++ b/.octopus/ubuntu.18.04/deployment_process.ocl
@@ -9,7 +9,7 @@ step "Push Docker image" {
             DockerPush.Target.Docker.Repository = "#{Docker.Registry.Target.Repository}"
             Octopus.Action.RunOnServer = "true"
             Octopus.Action.Template.Id = "ActionTemplates-2141"
-            Octopus.Action.Template.Version = "7"
+            Octopus.Action.Template.Version = "9"
         }
         worker_pool = "Hosted Ubuntu"
 


### PR DESCRIPTION
This paves the way for adding the "combined manifest" step to both ubuntu and windows projects on `deploy`. The changes are on the project variables. I've added 3 new variables to each project ([ubuntu](https://deploy.octopus.app/app#/Spaces-1163/projects/ubuntu-worker-tools/variables) and [windows](https://deploy.octopus.app/app#/Spaces-1163/projects/windows-worker-tools/variables))
- `WorkerTools.Tags.Major`
- `WorkerTools.Tags.Minor`
- `WorkerTools.Tags.Os`

where the `Major` and `Minor` are _just_ the semver part without the os suffix. The concat then happens in the step template source. These values are required for the combined manifest.

Adding them as new variables instead of modifying the existing variable just so we have some backward compatibility until the PR is merged. The old variables can be cleaned up once this is merged and the changes have taken effect.