### PR TITLE
Fix gitversion

### DIFF
--- a/gitversion.yml
+++ b/gitversion.yml
@@ -1,0 +1,1 @@
+mode: ContinuousDeployment

--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
     "version": "6.0.300",
-    "rollForward": "latestFeature"
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
   }
 }


### PR DESCRIPTION
This ensures the build number format is always a valid image tag, even in a non-release build. This should be the final code change for the pipeline 🤞  