### PR TITLE
Add docker manifest step to deployment process

### DIFF
--- a/.octopus/ubuntu.18.04/deployment_process.ocl
+++ b/.octopus/ubuntu.18.04/deployment_process.ocl
@@ -1,7 +1,8 @@
-step "Push Docker image" {
+step "push-docker-image" {
+    name = "Push Docker image"
 
     action {
-        environments = ["Staging", "Production"]
+        environments = ["staging", "production"]
         properties = {
             DockerPush.Target.Docker.Registry.Hostname = "#{Docker.Registry.Target.Hostname}"
             DockerPush.Target.Docker.Registry.Password = "#{Docker.Registry.Target.Password}"
@@ -9,13 +10,31 @@ step "Push Docker image" {
             DockerPush.Target.Docker.Repository = "#{Docker.Registry.Target.Repository}"
             Octopus.Action.RunOnServer = "true"
             Octopus.Action.Template.Id = "ActionTemplates-2141"
-            Octopus.Action.Template.Version = "7"
+            Octopus.Action.Template.Version = "10"
         }
-        worker_pool = "Hosted Ubuntu"
+        worker_pool = "hosted-ubuntu"
 
         container {
-            feed = "docker.packages.octopushq"
+            feed = "docker-packages-octopushq"
             image = "octopusdeploy/tool-containers/tool-skopeo-cli"
         }
+    }
+}
+
+step "create-docker-manifest" {
+    name = "Create Docker Manifest"
+
+    action {
+        environments = ["staging", "production"]
+        properties = {
+            DockerPush.Target.Docker.Registry.Hostname = "#{Docker.Registry.Target.Repository}"
+            DockerPush.Target.Docker.Registry.Password = "#{Docker.Registry.Target.Username}"
+            DockerPush.Target.Docker.Registry.Username = "#{Docker.Registry.Target.Hostname}"
+            DockerPush.Target.Docker.Repository = "#{Docker.Registry.Target.Password}"
+            Octopus.Action.RunOnServer = "true"
+            Octopus.Action.Template.Id = "ActionTemplates-2741"
+            Octopus.Action.Template.Version = "3"
+        }
+        worker_pool = "hosted-ubuntu"
     }
 }

--- a/.octopus/ubuntu.18.04/schema_version.ocl
+++ b/.octopus/ubuntu.18.04/schema_version.ocl
@@ -1,1 +1,1 @@
-version = 3
+version = 6

--- a/.octopus/windows.ltsc2019/deployment_process.ocl
+++ b/.octopus/windows.ltsc2019/deployment_process.ocl
@@ -1,7 +1,8 @@
-step "Push Docker image" {
+step "push-docker-image" {
+    name = "Push Docker image"
 
     action {
-        environments = ["Staging", "Production"]
+        environments = ["staging", "production"]
         properties = {
             DockerPush.Target.Docker.Registry.Hostname = "#{Docker.Registry.Target.Hostname}"
             DockerPush.Target.Docker.Registry.Password = "#{Docker.Registry.Target.Password}"
@@ -9,13 +10,31 @@ step "Push Docker image" {
             DockerPush.Target.Docker.Repository = "#{Docker.Registry.Target.Repository}"
             Octopus.Action.RunOnServer = "true"
             Octopus.Action.Template.Id = "ActionTemplates-2141"
-            Octopus.Action.Template.Version = "7"
+            Octopus.Action.Template.Version = "10"
         }
-        worker_pool = "Hosted Ubuntu"
+        worker_pool = "hosted-ubuntu"
 
         container {
-            feed = "docker.packages.octopushq"
+            feed = "docker-packages-octopushq"
             image = "octopusdeploy/tool-containers/tool-skopeo-cli"
         }
+    }
+}
+
+step "create-docker-manifest" {
+    name = "Create Docker Manifest"
+
+    action {
+        environments = ["staging", "production"]
+        properties = {
+            DockerPush.Target.Docker.Registry.Hostname = "#{Docker.Registry.Target.Repository}"
+            DockerPush.Target.Docker.Registry.Password = "#{Docker.Registry.Target.Username}"
+            DockerPush.Target.Docker.Registry.Username = "#{Docker.Registry.Target.Hostname}"
+            DockerPush.Target.Docker.Repository = "#{Docker.Registry.Target.Password}"
+            Octopus.Action.RunOnServer = "true"
+            Octopus.Action.Template.Id = "ActionTemplates-2741"
+            Octopus.Action.Template.Version = "3"
+        }
+        worker_pool = "hosted-ubuntu"
     }
 }

--- a/.octopus/windows.ltsc2019/schema_version.ocl
+++ b/.octopus/windows.ltsc2019/schema_version.ocl
@@ -1,1 +1,1 @@
-version = 3
+version = 6


### PR DESCRIPTION
This allows us to combine windows and linux into a single docker manifest.

Changes include:
- adding a new step to both ubuntu and windows to create a combined manifest
- update some of the variable usage in the existing docker push step to make the ☝️ step easier