### PR TITLE
Add xxd to ubuntu images

### DIFF
--- a/ubuntu.18.04/Dockerfile
+++ b/ubuntu.18.04/Dockerfile
@@ -154,7 +154,7 @@ RUN curl --silent --location https://github.com/opencontainers/umoci/releases/do
 # https://mikefarah.gitbook.io/yq/
 # https://augeas.net/
 RUN add-apt-repository -y ppa:rmescandon/yq && \
-    apt-get update && apt-get install -y jq yq openssh-client rsync git augeas-tools
+    apt-get update && apt-get install -y jq yq openssh-client rsync git augeas-tools xxd
 
 # Skopeo
 # https://github.com/containers/skopeo/blob/master/install.md

--- a/ubuntu.18.04/README.md
+++ b/ubuntu.18.04/README.md
@@ -56,3 +56,4 @@
 * rsync - Latest
 * git - Latest
 * augeas-tools - Latest
+* xxd - Latest

--- a/ubuntu.22.04/Dockerfile
+++ b/ubuntu.22.04/Dockerfile
@@ -182,5 +182,5 @@ RUN curl -sSL -o argocd-linux-amd64 https://github.com/argoproj/argo-cd/releases
 # https://mikefarah.gitbook.io/yq/
 # https://augeas.net/
 RUN add-apt-repository -y ppa:rmescandon/yq && \
-    apt-get update && apt-get install -y jq yq openssh-client rsync git augeas-tools && \
+    apt-get update && apt-get install -y jq yq openssh-client rsync git augeas-tools xxd && \
     rm -rf /var/lib/apt/lists/*

--- a/ubuntu.22.04/README.md
+++ b/ubuntu.22.04/README.md
@@ -64,3 +64,4 @@
 - rsync - Latest
 - git - Latest
 - augeas-tools - Latest
+- xxd - Latest


### PR DESCRIPTION
[sc-109023]

Adds `xxd` to ubuntu images.

Note: this requirement was introduced by https://github.com/OctopusDeploy/OctopusDeploy/pull/32363. This functionality is currently limited to internal users, meaning no customers are currently impacted by the fact our Ubuntu images do not include `xxd`.