### PR TITLE
Fix ubuntu tagging

### DIFF
--- a/.octopus/deploy-worker-tools/deployment_process.ocl
+++ b/.octopus/deploy-worker-tools/deployment_process.ocl
@@ -82,7 +82,7 @@ step "tag-and-push-worker-tools-image-windows-2022" {
             DockerPush.Target.Docker.Registry.Username = "#{Docker.Registry.Target.Username}"
             DockerPush.Target.Docker.Repository = "#{Docker.Registry.Target.Repository}"
             Octopus.Action.Template.Id = "ActionTemplates-2721"
-            Octopus.Action.Template.Version = "13"
+            Octopus.Action.Template.Version = "14"
         }
         worker_pool = "hosted-ubuntu"
 

--- a/.octopus/deploy-worker-tools/deployment_process.ocl
+++ b/.octopus/deploy-worker-tools/deployment_process.ocl
@@ -10,7 +10,7 @@ step "tag-and-push-worker-tools-image-ubuntu-22-04" {
             DockerPush.Target.Docker.Registry.Username = "#{Docker.Registry.Target.Username}"
             DockerPush.Target.Docker.Repository = "#{Docker.Registry.Target.Repository}"
             Octopus.Action.Template.Id = "ActionTemplates-2721"
-            Octopus.Action.Template.Version = "13"
+            Octopus.Action.Template.Version = "14"
         }
         worker_pool = "hosted-ubuntu"
 

--- a/.octopus/deploy-worker-tools/deployment_process.ocl
+++ b/.octopus/deploy-worker-tools/deployment_process.ocl
@@ -106,7 +106,7 @@ step "tag-and-push-worker-tools-image-windows-2025" {
             DockerPush.Target.Docker.Registry.Username = "#{Docker.Registry.Target.Username}"
             DockerPush.Target.Docker.Repository = "#{Docker.Registry.Target.Repository}"
             Octopus.Action.Template.Id = "ActionTemplates-2721"
-            Octopus.Action.Template.Version = "13"
+            Octopus.Action.Template.Version = "14"
         }
         worker_pool = "hosted-ubuntu"
 

--- a/.octopus/deploy-worker-tools/deployment_process.ocl
+++ b/.octopus/deploy-worker-tools/deployment_process.ocl
@@ -58,7 +58,7 @@ step "tag-and-push-worker-tools-image-ubuntu-24-04-arm64" {
             DockerPush.Target.Docker.Registry.Username = "#{Docker.Registry.Target.Username}"
             DockerPush.Target.Docker.Repository = "#{Docker.Registry.Target.Repository}"
             Octopus.Action.Template.Id = "ActionTemplates-2721"
-            Octopus.Action.Template.Version = "13"
+            Octopus.Action.Template.Version = "14"
         }
         worker_pool = "hosted-ubuntu"
 

--- a/.octopus/deploy-worker-tools/deployment_process.ocl
+++ b/.octopus/deploy-worker-tools/deployment_process.ocl
@@ -34,7 +34,7 @@ step "tag-and-push-worker-tools-image-ubuntu-24-04-amd64" {
             DockerPush.Target.Docker.Registry.Username = "#{Docker.Registry.Target.Username}"
             DockerPush.Target.Docker.Repository = "#{Docker.Registry.Target.Repository}"
             Octopus.Action.Template.Id = "ActionTemplates-2721"
-            Octopus.Action.Template.Version = "13"
+            Octopus.Action.Template.Version = "14"
         }
         worker_pool = "hosted-ubuntu"
 

--- a/.octopus/deploy-worker-tools/variables.ocl
+++ b/.octopus/deploy-worker-tools/variables.ocl
@@ -147,10 +147,6 @@ variable "Docker.Manifest.Image[windows2025]" {
     value "#{Docker.Registry.Target.Repository}:#{Octopus.Release.Number}-#{Docker.Tag.OS.Windows2025}" {}
 }
 
-variable "Release.Number.Wrapper" {
-    value "6.6.1-pr-0127.63" {}
-}
-
 variable "WorkerTools.Version.Full" {
     value "#{Release.Number.Wrapper}" {}
 
@@ -176,4 +172,8 @@ variable "WorkerTools.Version.MajorMinor" {
         action = ["build-multi-platform-manifest-ubuntu-24-04"]
         description = ""
     }
+}
+
+variable "Release.Number.Wrapper" {
+    value "#{Octopus.Release.Number}" {}
 }

--- a/.octopus/deploy-worker-tools/variables.ocl
+++ b/.octopus/deploy-worker-tools/variables.ocl
@@ -44,14 +44,29 @@ variable "Docker.Registry.Target.Username" {
 
 variable "WorkerTools.Version.Full" {
     value "#{Octopus.Release.Number}" {}
+
+    value "#{Octopus.Release.Number}-#{Docker.Tag.OS.Ubuntu2404.base}" {
+        action = ["build-multi-platform-manifest-ubuntu-24-04"]
+        description = ""
+    }
 }
 
 variable "WorkerTools.Version.Major" {
     value "#{Octopus.Release.Number | VersionMajor}" {}
+
+    value "#{Octopus.Release.Number | VersionMajor}-#{Docker.Tag.OS.Ubuntu2404.base}" {
+        action = ["build-multi-platform-manifest-ubuntu-24-04"]
+        description = ""
+    }
 }
 
 variable "WorkerTools.Version.MajorMinor" {
     value "#{Octopus.Release.Number | VersionMajor}.#{Octopus.Release.Number | VersionMinor}" {}
+
+    value "#{Octopus.Release.Number | VersionMajor}.#{Octopus.Release.Number | VersionMinor}-#{Docker.Tag.OS.Ubuntu2404.base}" {
+        action = ["build-multi-platform-manifest-ubuntu-24-04"]
+        description = ""
+    }
 }
 
 variable "Docker.Tag.FullVersion.OS" {

--- a/.octopus/deploy-worker-tools/variables.ocl
+++ b/.octopus/deploy-worker-tools/variables.ocl
@@ -173,3 +173,7 @@ variable "Docker.Manifest.Image[windows2022]" {
 variable "Docker.Manifest.Image[windows2025]" {
     value "#{Docker.Registry.Target.Repository}:#{Octopus.Release.Number}-#{Docker.Tag.OS.Windows2025}" {}
 }
+
+variable "TestReleaseNumber" {
+    value "6.6.1-pr-0127.63" {}
+}

--- a/.octopus/deploy-worker-tools/variables.ocl
+++ b/.octopus/deploy-worker-tools/variables.ocl
@@ -42,33 +42,6 @@ variable "Docker.Registry.Target.Username" {
     }
 }
 
-variable "WorkerTools.Version.Full" {
-    value "#{Octopus.Release.Number}" {}
-
-    value "#{Octopus.Release.Number}-#{Docker.Tag.OS.Ubuntu2404.base}" {
-        action = ["build-multi-platform-manifest-ubuntu-24-04"]
-        description = ""
-    }
-}
-
-variable "WorkerTools.Version.Major" {
-    value "#{Octopus.Release.Number | VersionMajor}" {}
-
-    value "#{Octopus.Release.Number | VersionMajor}-#{Docker.Tag.OS.Ubuntu2404.base}" {
-        action = ["build-multi-platform-manifest-ubuntu-24-04"]
-        description = ""
-    }
-}
-
-variable "WorkerTools.Version.MajorMinor" {
-    value "#{Octopus.Release.Number | VersionMajor}.#{Octopus.Release.Number | VersionMinor}" {}
-
-    value "#{Octopus.Release.Number | VersionMajor}.#{Octopus.Release.Number | VersionMinor}-#{Docker.Tag.OS.Ubuntu2404.base}" {
-        action = ["build-multi-platform-manifest-ubuntu-24-04"]
-        description = ""
-    }
-}
-
 variable "Docker.Tag.FullVersion.OS" {
     value "#{WorkerTools.Version.Full}-#{Docker.Image.Tag}" {}
 }
@@ -174,6 +147,33 @@ variable "Docker.Manifest.Image[windows2025]" {
     value "#{Docker.Registry.Target.Repository}:#{Octopus.Release.Number}-#{Docker.Tag.OS.Windows2025}" {}
 }
 
-variable "TestReleaseNumber" {
+variable "Release.Number.Wrapper" {
     value "6.6.1-pr-0127.63" {}
+}
+
+variable "WorkerTools.Version.Full" {
+    value "#{Release.Number.Wrapper}" {}
+
+    value "#{Release.Number.Wrapper}-#{Docker.Tag.OS.Ubuntu2404.base}" {
+        action = ["build-multi-platform-manifest-ubuntu-24-04"]
+        description = ""
+    }
+}
+
+variable "WorkerTools.Version.Major" {
+    value "#{Release.Number.Wrapper | VersionMajor}" {}
+
+    value "#{Release.Number.Wrapper | VersionMajor}-#{Docker.Tag.OS.Ubuntu2404.base}" {
+        action = ["build-multi-platform-manifest-ubuntu-24-04"]
+        description = ""
+    }
+}
+
+variable "WorkerTools.Version.MajorMinor" {
+    value "#{Release.Number.Wrapper | VersionMajor}.#{Release.Number.Wrapper | VersionMinor}" {}
+
+    value "#{Release.Number.Wrapper | VersionMajor}.#{Release.Number.Wrapper | VersionMinor}-#{Docker.Tag.OS.Ubuntu2404.base}" {
+        action = ["build-multi-platform-manifest-ubuntu-24-04"]
+        description = ""
+    }
 }

--- a/.octopus/deploy-worker-tools/variables.ocl
+++ b/.octopus/deploy-worker-tools/variables.ocl
@@ -135,26 +135,6 @@ variable "WorkerTools.Tags.LatestMajor" {
     value "#{WorkerTools.Version.Major}" {}
 }
 
-variable "Docker.Manifest.Image[ubuntu2204]" {
-    value "#{Docker.Registry.Target.Repository}:#{WorkerTools.Version.Full}-#{Docker.Tag.OS.Ubuntu2204}" {}
-}
-
-variable "Docker.Manifest.Image[ubuntu2404amd64]" {
-    value "#{Docker.Registry.Target.Repository}:#{WorkerTools.Version.Full}-#{Docker.Tag.OS.Ubuntu2404.amd64}" {}
-}
-
-variable "Docker.Manifest.Image[ubuntu2404arm64]" {
-    value "#{Docker.Registry.Target.Repository}:#{WorkerTools.Version.Full}-#{Docker.Tag.OS.Ubuntu2404.arm64}" {}
-}
-
-variable "Docker.Manifest.Image[windows2022]" {
-    value "#{Docker.Registry.Target.Repository}:#{WorkerTools.Version.Full}-#{Docker.Tag.OS.Windows2022}" {}
-}
-
-variable "Docker.Manifest.Image[windows2025]" {
-    value "#{Docker.Registry.Target.Repository}:#{WorkerTools.Version.Full}-#{Docker.Tag.OS.Windows2025}" {}
-}
-
 variable "Docker.Manifest.ImageArgs" {
     value "#{each image in Docker.Manifest.Image}#{image} #{/each}" {
         action = ["build-multi-platform-manifest"]
@@ -172,4 +152,24 @@ variable "WorkerTools.Version.Latest" {
     value "#{Docker.Tag.OS.Ubuntu2404.base}" {
         action = ["build-multi-platform-manifest-ubuntu-24-04"]
     }
+}
+
+variable "Docker.Manifest.Image[ubuntu2204]" {
+    value "#{Docker.Registry.Target.Repository}:#{Octopus.Release.Number}-#{Docker.Tag.OS.Ubuntu2204}" {}
+}
+
+variable "Docker.Manifest.Image[ubuntu2404amd64]" {
+    value "#{Docker.Registry.Target.Repository}:#{Octopus.Release.Number}-#{Docker.Tag.OS.Ubuntu2404.amd64}" {}
+}
+
+variable "Docker.Manifest.Image[ubuntu2404arm64]" {
+    value "#{Docker.Registry.Target.Repository}:#{Octopus.Release.Number}-#{Docker.Tag.OS.Ubuntu2404.arm64}" {}
+}
+
+variable "Docker.Manifest.Image[windows2022]" {
+    value "#{Docker.Registry.Target.Repository}:#{Octopus.Release.Number}-#{Docker.Tag.OS.Windows2022}" {}
+}
+
+variable "Docker.Manifest.Image[windows2025]" {
+    value "#{Docker.Registry.Target.Repository}:#{Octopus.Release.Number}-#{Docker.Tag.OS.Windows2025}" {}
 }


### PR DESCRIPTION
There was an issue with the way the Ubuntu24.04 aRM and aMD64 images were combined in a manifest. This  fixes the affected variables